### PR TITLE
Force activation refinements

### DIFF
--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -98,8 +98,10 @@ class Force_Plugin_Activation {
 		// Add our force-activated plugins
 		$plugins = array_merge( (array) $plugins, $this->force_active );
 
-		// Remove our force-deactivated plguins
-		$plugins = array_diff( (array) $plugins, $this->force_deactive );
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			// Remove our force-deactivated plguins unless WP_DEBUG is on
+			$plugins = array_diff( (array)$plugins, $this->force_deactive );
+		}
 
 		// Deduplicate
 		$plugins = array_unique( $plugins );
@@ -129,8 +131,10 @@ class Force_Plugin_Activation {
 			unset( $actions['deactivate'] );
 		}
 
-		if ( in_array( $plugin_file, $this->force_deactive ) ) {
-			unset( $actions['activate'] );
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			if ( in_array( $plugin_file, $this->force_deactive ) ) {
+				unset( $actions[ 'activate' ] );
+			}
 		}
 
 		return $actions;
@@ -168,7 +172,4 @@ class Force_Plugin_Activation {
 
 }
 
-// We want to enfornce only on production, where WP_DEBUG is off.
-if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-	new Force_Plugin_Activation();
-}
+new Force_Plugin_Activation();


### PR DESCRIPTION
First commit is just some cleanup. The second represents a philosophical change, always running force activation, and only running force deactivation when WP_DEBUG is off.
