### PR TITLE
Update path variables to css variable syntax.

### DIFF
--- a/wp-content/themes/core/pcss/base/_icons.pcss
+++ b/wp-content/themes/core/pcss/base/_icons.pcss
@@ -6,12 +6,12 @@
 
 @font-face {
 	font-family: 'core-icons';
-	src: url('$(dir-fonts)/icons-core/core-icons.eot?3y5h49');
+	src: url('var(--dir-fonts)/icons-core/core-icons.eot?3y5h49');
 	src:
-		url('$(dir-fonts)/icons-core/core-icons.eot?3y5h49#iefix') format('embedded-opentype'),
-		url('$(dir-fonts)/icons-core/core-icons.ttf?3y5h49') format('truetype'),
-		url('$(dir-fonts)/icons-core/core-icons.woff?3y5h49') format('woff'),
-		url('$(dir-fonts)/icons-core/core-icons.svg?3y5h49#core-icons') format('svg');
+		url('var(--dir-fonts)/icons-core/core-icons.eot?3y5h49#iefix') format('embedded-opentype'),
+		url('var(--dir-fonts)/icons-core/core-icons.ttf?3y5h49') format('truetype'),
+		url('var(--dir-fonts)/icons-core/core-icons.woff?3y5h49') format('woff'),
+		url('var(--dir-fonts)/icons-core/core-icons.svg?3y5h49#core-icons') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }

--- a/wp-content/themes/core/pcss/utilities/variables/_paths.pcss
+++ b/wp-content/themes/core/pcss/utilities/variables/_paths.pcss
@@ -1,2 +1,4 @@
-$dir-images: '/wp-content/themes/core/img';
-$dir-fonts: '/wp-content/themes/core/fonts';
+:root {
+	--dir-images: /wp-content/themes/core/img;
+	--dir-fonts: /wp-content/themes/core/fonts;
+}


### PR DESCRIPTION
This PR updates the CSS path variables ot use the newer CSS syntax like other vars in the theme. `$dir-images` & `$dir-fonts` weren't expanding when used. They were blank.

New syntax is `--dir-images` & `--dir-fonts`
