### PR TITLE
Make Pimple container available to Post Type objects

### DIFF
--- a/wp-content/plugins/core/src/Service_Providers/Tribe_Service_Provider.php
+++ b/wp-content/plugins/core/src/Service_Providers/Tribe_Service_Provider.php
@@ -68,7 +68,7 @@ abstract class Tribe_Service_Provider implements ServiceProviderInterface {
 		foreach ( $this->post_types as $type ) {
 			$container[ 'post_type.' . $type ] = function ( $container ) use ( $type ) {
 				$post_type_class_name = '\\Tribe\\Project\\Post_Types\\' . $type;
-				return new $post_type_class_name;
+				return new $post_type_class_name( $container );
 			};
 			$container[ 'post_type.' . $type . '.config' ] = function ( $container ) use ( $type ) {
 				$config_class_name = '\\Tribe\\Project\\Post_Types\\Config\\' . $type;


### PR DESCRIPTION
Starting out nice and simple on this one - I've found it useful to have the Pimple container available to Post Type objects. This simply passes it as a parameter when they're set up so the __construct can access it if necessary. 
