### PR TITLE
Add exception to p2p for registering Users in connections

### DIFF
--- a/wp-content/plugins/core/src/Service_Providers/Tribe_Service_Provider.php
+++ b/wp-content/plugins/core/src/Service_Providers/Tribe_Service_Provider.php
@@ -136,7 +136,7 @@ abstract class Tribe_Service_Provider implements ServiceProviderInterface {
 	}
 
 	protected function post_type_is_user( $side ) {
-		return in_array( 'User', $side, true );
+		return ( in_array( 'User', $side ) || in_array( 'user', $side ) );
 	}
 
 	protected function map_post_type_classes_to_ids( $post_type_classes, $container ) {


### PR DESCRIPTION
This is related to our previous discussion about being able to register User connections using our P2P framework. I took the route of simply adding an exception into the `p2p()` method rather than writing a new framework. I did this mostly because in the end, I think p2p really references the plugin name (Posts 2 Posts) and not necessarily the connection type. 

Because of the way Posts 2 Posts checks for `users` as the connection type, I had to return a `string` of `user` vs. an array as we do with the other types. This really has one drawback that I can think of - you can't register a connection to an array of post types which includes `user`. This seems acceptable to me as P2P handles it completely differently, so we probably shouldn't be registering a single connection for post types and users anyways. 
