### PR TITLE
Bemify up WP nav menus, barebones starter (<a> to <button> filter for…

### DIFF
--- a/wp-content/plugins/core/src/Service_Providers/Global_Service_Provider.php
+++ b/wp-content/plugins/core/src/Service_Providers/Global_Service_Provider.php
@@ -22,8 +22,8 @@ use Tribe\Project\P2P\Titles_Filter;
 final class Global_Service_Provider extends Tribe_Service_Provider {
 
 	protected $nav_menus = [
-		'primary'   => 'Menu: Site',
-		'secondary' => 'Menu: Footer',
+		'nav-primary'   => 'Menu: Site',
+		'nav-secondary' => 'Menu: Footer',
 	];
 
 	protected $p2p_relationships = [

--- a/wp-content/plugins/core/src/Theme/Nav/Walker_Nav_Menu_Primary.php
+++ b/wp-content/plugins/core/src/Theme/Nav/Walker_Nav_Menu_Primary.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tribe\Project\Theme\Nav;
+
+/**
+ * Class Walker_Nav_Menu_Primary
+ *
+ * Just like \Walker_Nav_Menu, but for primary site navigation
+ *
+ * @package Tribe\Project\Nav
+ */
+class Walker_Nav_Menu_Primary extends \Walker_Nav_Menu {
+
+	// Capture our parent item for a sub-menu
+	private $current_item;
+
+	/**
+	 * Starts the list before the elements are added.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @see   Walker::start_lvl()
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param int    $depth  Depth of menu item. Used for padding.
+	 * @param array  $args   An array of wp_nav_menu() arguments.
+	 */
+	public function start_lvl( &$output, $depth = 0, $args = array() ) {
+
+		// Setup sub-menu ID
+		$id = $this->current_item->ID ? ' id="menu-item-child-' . esc_attr( $this->current_item->ID ) . '"' : '';
+
+		// Setup sub-menu classes
+		$classes = 'navigation__list-child navigation__list-child--depth-' . $depth;
+
+		$indent = str_repeat("\t", $depth);
+		$output .= "\n$indent<ul$id class=\"$classes\">\n";
+
+	}
+
+	/**
+	 * Starts the element output.
+	 *
+	 * @since 3.0.0
+	 * @since 4.4.0 The {@see 'nav_menu_item_args'} filter was added.
+	 *
+	 * @see   Walker::start_el()
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param object $item   Menu item data object.
+	 * @param int    $depth  Depth of menu item. Used for padding.
+	 * @param array  $args   An array of wp_nav_menu() arguments.
+	 * @param int    $id     Current item ID.
+	 */
+	public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
+
+		//var_dump( $item );
+
+		// Setup our parent item
+        $this->current_item = $item;
+
+		$indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+
+		$classes   = empty( $item->classes ) ? array() : (array)$item->classes;
+		$classes[] = 'menu-item-' . $item->ID;
+
+		/**
+		 * Filters the arguments for a single nav menu item.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param array  $args  An array of arguments.
+		 * @param object $item  Menu item data object.
+		 * @param int    $depth Depth of menu item. Used for padding.
+		 */
+		$args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
+
+		/**
+		 * Filters the CSS class(es) applied to a menu item's list item element.
+		 *
+		 * @since 3.0.0
+		 * @since 4.1.0 The `$depth` parameter was added.
+		 *
+		 * @param array  $classes The CSS classes that are applied to the menu item's `<li>` element.
+		 * @param object $item    The current menu item.
+		 * @param array  $args    An array of wp_nav_menu() arguments.
+		 * @param int    $depth   Depth of menu item. Used for padding.
+		 */
+		$class_names = join( ' ',
+			apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
+		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+
+		/**
+		 * Filters the ID applied to a menu item's list item element.
+		 *
+		 * @since 3.0.1
+		 * @since 4.1.0 The `$depth` parameter was added.
+		 *
+		 * @param string $menu_id The ID that is applied to the menu item's `<li>` element.
+		 * @param object $item    The current menu item.
+		 * @param array  $args    An array of wp_nav_menu() arguments.
+		 * @param int    $depth   Depth of menu item. Used for padding.
+		 */
+		$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
+		$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
+
+		$output .= $indent . '<li' . $id . $class_names . '>';
+
+		$atts           = array();
+		$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
+		$atts['target'] = ! empty( $item->target ) ? $item->target : '';
+		$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
+		$atts['href']   = ! empty( $item->url ) ? $item->url : '';
+
+		/**
+		 * Filters the HTML attributes applied to a menu item's anchor element.
+		 *
+		 * @since 3.6.0
+		 * @since 4.1.0 The `$depth` parameter was added.
+		 *
+		 * @param array  $atts   {
+		 *                       The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
+		 *
+		 * @type string  $title  Title attribute.
+		 * @type string  $target Target attribute.
+		 * @type string  $rel    The rel attribute.
+		 * @type string  $href   The href attribute.
+		 * }
+		 *
+		 * @param object $item   The current menu item.
+		 * @param array  $args   An array of wp_nav_menu() arguments.
+		 * @param int    $depth  Depth of menu item. Used for padding.
+		 */
+		$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
+
+		$attributes = '';
+		foreach ( $atts as $attr => $value ) {
+			if ( ! empty( $value ) ) {
+				$value = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+				$attributes .= ' ' . $attr . '="' . $value . '"';
+			}
+		}
+
+		/** This filter is documented in wp-includes/post-template.php */
+		$title = apply_filters( 'the_title', $item->title, $item->ID );
+
+		/**
+		 * Filters a menu item's title.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param string $title The menu item's title.
+		 * @param object $item  The current menu item.
+		 * @param array  $args  An array of wp_nav_menu() arguments.
+		 * @param int    $depth Depth of menu item. Used for padding.
+		 */
+		$title = apply_filters( 'nav_menu_item_title', $title, $item, $args, $depth );
+
+		$item_output = $args->before;
+		$item_output .= '<a' . $attributes . '>';
+		$item_output .= $args->link_before . $title . $args->link_after;
+		$item_output .= '</a>';
+		$item_output .= $args->after;
+
+		/**
+		 * Filters a menu item's starting output.
+		 *
+		 * The menu item's starting output only includes `$args->before`, the opening `<a>`,
+		 * the menu item's title, the closing `</a>`, and `$args->after`. Currently, there is
+		 * no filter for modifying the opening and closing `<li>` for a menu item.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $item_output The menu item's starting HTML output.
+		 * @param object $item        Menu item data object.
+		 * @param int    $depth       Depth of menu item. Used for padding.
+		 * @param array  $args        An array of wp_nav_menu() arguments.
+		 */
+		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+	}
+}

--- a/wp-content/themes/core/content/navigation/footer.php
+++ b/wp-content/themes/core/content/navigation/footer.php
@@ -1,13 +1,13 @@
-<?php if( has_nav_menu( 'secondary' ) ) { ?>
+<?php if( has_nav_menu( 'nav-secondary' ) ) { ?>
 
-	<nav class="site-footer__nav" aria-labelledby="site-footer__nav-label">
+	<nav class="nav-secondary" aria-labelledby="nav-secondary__label">
 
-		<h2 id="site-footer__nav-label" class="u-visual-hide"><?php _e( 'Secondary Navigation', 'tribe' ); ?></h2>
+		<h2 id="nav-secondary__label" class="u-visual-hide"><?php _e( 'Secondary Navigation', 'tribe' ); ?></h2>
 
-		<ol class="site-footer__nav-list">
+		<ol class="nav-secondary__list">
 			<?php
 			$defaults = array(
-				'theme_location'  => 'secondary',
+				'theme_location'  => 'nav-secondary',
 				'container'       => false,
 				'container_class' => '',
 				'menu_class'      => '',

--- a/wp-content/themes/core/content/navigation/header.php
+++ b/wp-content/themes/core/content/navigation/header.php
@@ -1,22 +1,25 @@
-<?php if( has_nav_menu( 'primary' ) ) { ?>
+<?php
+use Tribe\Project\Theme\Nav;
+if( has_nav_menu( 'nav-secondary' ) ) { ?>
 
-	<nav class="site-header__nav" aria-labelledby="site-header__nav-label">
+	<nav class="nav-primary" aria-labelledby="nav-primary__label">
 
-		<h2 id="site-header__nav-label" class="u-visual-hide"><?php _e( 'Primary Navigation', 'tribe' ); ?></h2>
+		<h2 id="nav-primary__label" class="u-visual-hide"><?php _e( 'Primary Navigation', 'tribe' ); ?></h2>
 
-		<ol class="site-header__nav-list">
+		<ol class="nav-primary__list">
 			<?php // Header Nav
 			$defaults = array(
-				'theme_location'  => 'primary',
+				'theme_location'  => 'nav-secondary',
 				'container'       => false,
 				'container_class' => '',
 				'menu_class'      => '',
 				'menu_id'         => '',
 				'depth'           => 3,
 				'items_wrap'      => '%3$s',
+				'walker'          => new Nav\Walker_Nav_Menu_Primary,
 				'fallback_cb'     => false
 			);
-			\Tribe\Project\Theme\Nav\Menu::menu( $defaults );
+			Nav\Menu::menu( $defaults );
 			?>
 		</ol>
 


### PR DESCRIPTION
- Bemifies WP nav menus css
- Adds a typical primary site navigation walker to add accessibility and other attributes to child menus
- Update theme boiler for header and footer nav templates