### PR TITLE
Don’t output nonexistent intermedia sizes for srcset.

### DIFF
--- a/wp-content/plugins/core/src/Theme/Image.php
+++ b/wp-content/plugins/core/src/Theme/Image.php
@@ -213,7 +213,7 @@ class Image {
 		foreach ( $this->options[ 'srcset_sizes' ] as $size ) {
 			$src = wp_get_attachment_image_src( $this->image_id, $size );
 			// Don't add nonexistent intermediate sizes to the src_set. It ends up being the full-size URL.
-			if( 'full' !== $size && true == $src[3] ) {
+			if( 'full' !== $size && true === $src[3] ) {
 				$attribute[] = sprintf( '%s %dw %dh', $src[0], $src[1], $src[2] );
 			}
 		}


### PR DESCRIPTION
If a size requested by the user doesn't exist, WordPress's `wp_get_attachment_image_src()` will return the full-size image in place of the nonexistent size. By default, this ends up outputting the full-size image URL for srcset attributes. 

`wp_get_attachment_image_src()`'s response includes an `is_intermediate` value that's true if the request image size is actually available (as long as the request isn't for the full size image).

I'm confirming that the requested size is not 'full' and `is_intermediate` is true before adding each size to the srcset attribute that is returned.