### PR TITLE
Implement new video wall custom plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:watch": "npm test -- --watch"
   },
   "dependencies": {
+    "@vimeo/player": "^2.0.1",
     "babel-polyfill": "^6.22.0",
     "delegate": "^3.1.2",
     "gsap": "^1.19.1",

--- a/wp-content/plugins/core/assets/theme/js/src/utils/dom/video-bg.js
+++ b/wp-content/plugins/core/assets/theme/js/src/utils/dom/video-bg.js
@@ -1,11 +1,40 @@
 /**
  * @desc Embed a youtube or vimeo video and make it fill its parent container on init and resize.
- * Vimeo support depends on their froogaloop mini lib.
+ * You can use the default export to automatically apply it to all found on the page. The required dom is:
+ *
+ * <div class="tribe-video-wall" data-js="tribe-video-wall" data-url="youtube or vimeo page url"></div>
+ *
+ * OR
+ *
+ * <div class="tribe-video-wall" data-js="tribe-video-wall" data-id="youtube or vimeo video id" data-type="youtube or vimeo"></div>
+ *
+ * To kick it on simply import tribeVideoWall from '../utils/dom/video-bg'; in plugins.js
+ *
+ * and
+ *
+ * tribeVideoWall();
+ *
+ * in init.
+ *
+ * Or you can use the individual init that is exported below (or other helpers) do have more control on a per instance basis.
  */
 
 import _ from 'lodash';
+import VimeoPlayer from '@vimeo/player';
 
-export const getVideoId = (url = '') => {
+import { browserTests } from '../tests';
+import * as tools from '../tools';
+
+const browser = browserTests();
+
+/**
+ * Takes a url and returns an object containing video id and type for youtube and vimeo videos, or null if not found.
+ *
+ * @param url
+ * @returns {*}
+ */
+
+export const getVideoConfig = (url = '') => {
 	let videoId = null;
 	if (url.indexOf('vimeo') !== -1) {
 		const regex = /https?:\/\/(?:www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^\/]*)\/videos\/|album\/(\d+)\/video\/|)(\d+)(?:$|\/|\?)/;
@@ -19,12 +48,74 @@ export const getVideoId = (url = '') => {
 	return videoId;
 };
 
+/**
+ * Takes a string and checks if it contains vimeo/youtube identifiers associated with their video page urls
+ *
+ * @param url
+ */
+
 export const isVideoUrl = (url = '') => url.indexOf('vimeo') !== -1 || url.indexOf('youtube') !== -1 || url.indexOf('youtu.be') !== -1;
+
+/**
+ * Injects the minimum required css for the walls to function correctly. Additional styles can be done in theme.
+ */
+
+const injectCSS = () => {
+	const css = document.createElement('style');
+	css.id = 'tribe-video-wall-css';
+	css.type = 'text/css';
+	css.innerHTML = `
+	.tribe-video-wall {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 2;
+		overflow: hidden;
+		opacity: 0;
+		transition: opacity 500ms ease-in;
+	}
+	
+	.tribe-video-wall.loaded {
+		opacity: 1;
+	}
+	
+	.tribe-video-wall:after {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 3;
+	}
+	
+	.tribe-video-wall__iframe {
+		width: 100%;
+		height: 100%;
+		position: absolute;
+		top: 0;
+		left: 0;
+		max-width: none;
+		max-height: none;
+		min-width: 100%;
+	}
+	`;
+	document.getElementsByTagName('head')[0].appendChild(css);
+};
+
+/**
+ * Inits an instance of a video wall
+ *
+ * @param opts
+ */
 
 export const init = (opts = {}) => {
 	const options = {
 		container: null,
 		id: '',
+		url: '',
 		resize_event: 'modern_tribe/resize_executed',
 		type: 'youtube',
 	};
@@ -32,9 +123,32 @@ export const init = (opts = {}) => {
 	// merge options
 	Object.assign(options, opts);
 
+	// dont run on mobile, they wont autoplay and this hurts them
+	if (browser.android || browser.ios) {
+		return;
+	}
+
+	// check if we should parse url or already have video id
+	if (!options.id.length && options.url.length) {
+		if (!isVideoUrl(options.url)) {
+			return;
+		}
+		const videoConfig = getVideoConfig(options.url);
+		if (!videoConfig) {
+			return;
+		}
+		options.id = videoConfig.id;
+		options.type = videoConfig.type;
+	}
+
+	// check for container and id
 	if (!options.container || !options.id.length) {
 		// need these, leaving town
 		return;
+	}
+
+	if (!document.getElementById('tribe-video-wall-css')) {
+		injectCSS();
 	}
 
 	// setup shared elements and values
@@ -48,6 +162,7 @@ export const init = (opts = {}) => {
 
 	// setup shared defaults on the iframe and container
 	iframe.id = iframeId;
+	iframe.classList.add('tribe-video-wall__iframe');
 	iframe.setAttribute('webkitallowfullscreen', '');
 	iframe.setAttribute('mozallowfullscreen', '');
 	iframe.setAttribute('allowfullscreen', '');
@@ -85,10 +200,12 @@ export const init = (opts = {}) => {
 		const ytContainer = document.createElement('div');
 		ytContainer.id = ytId;
 		options.container.appendChild(ytContainer);
-		const tag = document.createElement('script');
-		tag.src = 'https://www.youtube.com/iframe_api';
-		const firstScriptTag = document.getElementsByTagName('script')[0];
-		firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+		if (!window.YT) {
+			const tag = document.createElement('script');
+			tag.src = 'https://www.youtube.com/iframe_api';
+			const firstScriptTag = document.getElementsByTagName('script')[0];
+			firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+		}
 
 		window.onYouTubeIframeAPIReady = () => {
 			player = new window.YT.Player(ytId, {
@@ -102,6 +219,7 @@ export const init = (opts = {}) => {
 				events: {
 					onReady: (event) => {
 						iframeVideo = document.getElementById(ytId);
+						iframeVideo.classList.add('tribe-video-wall__iframe');
 						h = iframeVideo.getAttribute('height');
 						w = iframeVideo.getAttribute('width');
 						iframeVideo.style.transform = 'scale(1.1)';
@@ -110,7 +228,11 @@ export const init = (opts = {}) => {
 						event.target.setLoop(true);
 						event.target.mute();
 						event.target.playVideo();
-						_.delay(() => options.container.classList.add('loaded'), 800);
+					},
+					onStateChange: (event) => {
+						if (event.data === window.YT.PlayerState.PLAYING) {
+							options.container.classList.add('loaded');
+						}
 					},
 				},
 			});
@@ -118,19 +240,28 @@ export const init = (opts = {}) => {
 	};
 
 	const embedVimeo = () => {
-		iframe.src = `//player.vimeo.com/video/${options.id}?background=1&api=1&player_id=${iframeId}`;
+		iframe.src = `//player.vimeo.com/video/${options.id}?background=1&autoplay=0&mute=0&loop=0`;
 		options.container.appendChild(iframe);
 		iframeVideo = document.getElementById(iframeId);
-		player = window.$f(iframeVideo);
-		player.addEvent('ready', () => {
-			player.api('getVideoHeight', (value) => {
-				h = value;
-			});
-			player.api('getVideoWidth', (value) => {
-				w = value;
-				fitVideoToContainer();
-				_.delay(() => options.container.classList.add('loaded'), 800);
-			});
+		iframeVideo.setAttribute('data-vimeo-loop', 'true');
+		iframeVideo.setAttribute('data-vimeo-byline', 'false');
+		iframeVideo.setAttribute('data-vimeo-portrait', 'false');
+		iframeVideo.setAttribute('data-vimeo-title', 'false');
+
+		player = new VimeoPlayer(iframeVideo);
+		player.getVideoHeight().then((value) => {
+			h = value;
+		});
+		player.getVideoWidth().then((value) => {
+			w = value;
+			fitVideoToContainer();
+		});
+		player.getEnded().then(() => player.play());
+		player.ready().then(() => {
+			player.play();
+			player.setVolume(0);
+			player.setLoop(true);
+			_.delay(() => options.container.classList.add('loaded'), 400);
 		});
 	};
 
@@ -151,3 +282,58 @@ export const init = (opts = {}) => {
 		break;
 	}
 };
+
+/**
+ * Sets up init for a single instance from the initAll loop.
+ *
+ * @param data
+ */
+
+const setupInit = (data = {}) => {
+	const options = {
+		container: data.container,
+		resize_event: data.options.resize_event,
+	};
+
+	// if we have a url, use that and exit
+	if (data.container.dataset.url) {
+		options.url = data.container.dataset.url;
+		init(options);
+		return;
+	}
+
+	// we didnt have a url but got both and id and a type, lets use that
+	if (data.container.dataset.id && data.container.dataset.type) {
+		options.id = data.container.dataset.id;
+		options.type = data.container.dataset.type;
+		init(options);
+	}
+};
+
+/**
+ * Default export to init all on page
+ *
+ * @param opts
+ */
+
+const initAll = (opts = {}) => {
+	// dont run on mobile, they wont autoplay and this hurts them
+	if (browser.android || browser.ios) {
+		return;
+	}
+
+	const options = {
+		selector: 'tribe-video-wall',
+		resize_event: 'modern_tribe/resize_executed',
+	};
+
+	// merge options
+	Object.assign(options, opts);
+
+	const videoWalls = tools.getNodes(options.selector, true);
+	videoWalls.forEach(container => setupInit({ container, options }));
+
+	console.info(`Initialized Tribe Video Wall on ${videoWalls.length} element${videoWalls.length > 1 ? 's' : ''}.`);
+};
+
+export default initAll;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@vimeo/player@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vimeo/player/-/player-2.0.1.tgz#9ddb550d2f51018f8c5549ef0193e07903e5b2fc"
+  dependencies:
+    es6-collections "0.5.6"
+    native-promise-only "0.8.1"
+
 JSONStream@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
@@ -263,10 +270,6 @@ async@^2.1.2, async@^2.1.4:
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
   dependencies:
     lodash "^4.14.0"
-
-async@~0.2.6:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2101,6 +2104,10 @@ es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.
     es6-iterator "2"
     es6-symbol "~3.1"
 
+es6-collections@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/es6-collections/-/es6-collections-0.5.6.tgz#5552e800ad12c1820cda2bd4a79ae7dbb03d89a2"
+
 es6-iterator@2:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.0.tgz#bd968567d61635e33c0b80727613c9cb4b096bac"
@@ -2469,10 +2476,6 @@ extsprintf@1.0.2:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-fastclick@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/fastclick/-/fastclick-1.0.6.tgz#161625b27b1a5806405936bda9a2c1926d06be6a"
 
 faye-websocket@^0.10.0, faye-websocket@~0.10.0:
   version "0.10.0"
@@ -4403,6 +4406,10 @@ mz@^2.3.1:
 nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+
+native-promise-only@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -6710,16 +6717,7 @@ ua-parser-js@0.7.12:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.6, uglify-js@^2.7.5:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
-  dependencies:
-    async "~0.2.6"
-    source-map "~0.5.1"
-    uglify-to-browserify "~1.0.0"
-    yargs "~3.10.0"
-
-uglify-js@~2.8.3:
+uglify-js@^2.6, uglify-js@^2.7.5, uglify-js@~2.8.3:
   version "2.8.7"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.7.tgz#e0391911507b6d2e05697a528f1686e90a11b160"
   dependencies:
@@ -6904,18 +6902,9 @@ webidl-conversions@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.0.tgz#0a8c727ae4e5649687b7742368dcfbf13ed40118"
 
-webpack-dev-middleware@^1.10.1:
+webpack-dev-middleware@^1.10.1, webpack-dev-middleware@^1.9.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.1.tgz#c6b4cf428139cf1aefbe06a0c00fdb4f8da2f893"
-  dependencies:
-    memory-fs "~0.4.1"
-    mime "^1.3.4"
-    path-is-absolute "^1.0.0"
-    range-parser "^1.0.3"
-
-webpack-dev-middleware@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz#7d5be2651e692fddfafd8aaed177c16ff51f0eb8"
   dependencies:
     memory-fs "~0.4.1"
     mime "^1.3.4"
@@ -7120,7 +7109,7 @@ yargs-parser@^4.0.2, yargs-parser@^4.1.0, yargs-parser@^4.2.0:
   dependencies:
     camelcase "^3.0.0"
 
-yargs@3.29.0, yargs@^3.5.4:
+yargs@3.29.0:
   version "3.29.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.29.0.tgz#1aab9660eae79d8b8f675bcaeeab6ee34c2cf69c"
   dependencies:
@@ -7154,6 +7143,15 @@ yargs@^1.2.6:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.3.3.tgz#054de8b61f22eefdb7207059eaef9d6b83fb931a"
 
+yargs@^3.5.4, yargs@~3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
+  dependencies:
+    camelcase "^1.0.2"
+    cliui "^2.1.0"
+    decamelize "^1.0.0"
+    window-size "0.1.0"
+
 yargs@^6.0.0, yargs@^6.3.0, yargs@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
@@ -7171,15 +7169,6 @@ yargs@^6.0.0, yargs@^6.3.0, yargs@^6.6.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
-
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
This is a rewrite of the custom video wall i wrote for looping video backgrounds that are responsive and fill their container with no black bars. Supports youtube and vimeo. The system has been greatly simplified. You can still call methods directly to cover instantiation yourself but to enable for all walls on page its now as easy as:

```html
<div 
     class="tribe-video-wall" 
     data-js="tribe-video-wall" 
     data-url="youtube or vimeo page url"
></div>
```
throughout your page and
```javascript
import tribeVideoWall from '../utils/dom/video-bg';

const plugins = () => {
	tribeVideoWall();
};
```

in your plugins js.

uses new apis for both services.