### PR TITLE
environment variables -> php constants

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -39,7 +39,7 @@ function tribe_isSSL() {
 function tribe_getenv($name, $default = null) {
 	$env = getenv($name);
 	if ( $env === false ) return $default;
-	if ( $env == "false" || $env == "true" ) return filter_var($env, FILTER_VALIDATE_BOOLEAN);
+	if ( strtolower(trim($env)) == "false" || strtolower(trim($env)) == "true" ) return filter_var(strtolower(trim($env)), FILTER_VALIDATE_BOOLEAN);
 	if ( is_numeric($env) ) return ($env - 0);
 	return $env;
 }


### PR DESCRIPTION
One lesson learned from the findlaw work today, best to have defined environment variables work as php constants as well.  You all can let me know if you see any potential problems with this though.