### PR TITLE
adds visibility to method that had no explicit visibility definition

### DIFF
--- a/wp-content/plugins/tribe-admin-dashboard/Tribe_AdminDashboard.php
+++ b/wp-content/plugins/tribe-admin-dashboard/Tribe_AdminDashboard.php
@@ -83,7 +83,7 @@ class Tribe_AdminDashboard {
 	 * @todo handle styling externally
 	 * @todo dynamically manage welcome content per site, globally, and possibly per user role.
 	 */
-	function dashboard_panel() {
+	public function dashboard_panel() {
 		?>
 		
 		<style>


### PR DESCRIPTION
A simple thing, but may as well fix it.