### PR TITLE
Move the ca generation to cert.sh instead of start.sh so first docker usage is less frustrating

### DIFF
--- a/dev/docker/global/cert.sh
+++ b/dev/docker/global/cert.sh
@@ -10,6 +10,19 @@ SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 
 cd "$SCRIPTDIR";
 
+if [ ! -f "${SCRIPTDIR}/certs/tribeCA.key" ]; then
+	echo "Generating certificate authority"
+
+	openssl req -x509 -new -nodes -sha256 -newkey rsa:4096 -days 3650 \
+		-keyout "${SCRIPTDIR}/certs/tribeCA.key" \
+		-out "${SCRIPTDIR}/certs/tribeCA.pem" \
+		-subj "/C=US/ST=California/L=Santa Cruz/O=Modern Tribe/OU=Dev/CN=tri.be";
+
+	if [[ $OSTYPE == darwin* ]]; then
+		sudo security add-trusted-cert -d -r trustRoot -e hostnameMismatch -k /Library/Keychains/System.keychain "${SCRIPTDIR}/certs/tribeCA.pem";
+	fi;
+fi;
+
 echo "Generating SSL certificate for $DOMAIN";
 
 openssl req -new -nodes -sha256 -newkey rsa:4096 -days 3650 \

--- a/dev/docker/global/start.sh
+++ b/dev/docker/global/start.sh
@@ -23,19 +23,6 @@ if [ ! -f "${SCRIPTDIR}/.env" ]; then
 	fi;
 fi;
 
-if [ ! -f "${SCRIPTDIR}/certs/tribeCA.key" ]; then
-	echo "Generating certificate authority"
-
-	openssl req -x509 -new -nodes -sha256 -newkey rsa:4096 -days 3650 \
-		-keyout "${SCRIPTDIR}/certs/tribeCA.key" \
-		-out "${SCRIPTDIR}/certs/tribeCA.pem" \
-		-subj "/C=US/ST=California/L=Santa Cruz/O=Modern Tribe/OU=Dev/CN=tri.be";
-
-	if [[ $OSTYPE == darwin* ]]; then
-		sudo security add-trusted-cert -d -r trustRoot -e hostnameMismatch -k /Library/Keychains/System.keychain "${SCRIPTDIR}/certs/tribeCA.pem";
-	fi;
-fi;
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	DC_COMMAND="docker-compose"
 elif [[ $(which docker.exe) ]]; then


### PR DESCRIPTION
It also makes more sense to have all the cert related code in the same place, unless I'm missing something.