### PR TITLE
Updating 404 template

### DIFF
--- a/wp-content/plugins/core/src/Templates/Error_404.php
+++ b/wp-content/plugins/core/src/Templates/Error_404.php
@@ -3,7 +3,28 @@
 
 namespace Tribe\Project\Templates;
 
-
 class Error_404 extends Base {
 
+	public function get_data(): array {
+		$data                              = parent::get_data();
+		$data['post']                      = $this->get_post();
+		$data['error_404_browser_title']   = $this->get_404_page_title();
+		$data['error_404_browser_content'] = $this->get_404_page_content();
+
+		return $data;
+	}
+
+	protected function get_post() {
+		return [
+			'title' => __( 'Page Not Found', 'tribe' ),
+		];
+	}
+
+	protected function get_404_page_title() {
+		return __( 'Whoops! We are having trouble locating your page!', 'tribe' );
+	}
+
+	protected function get_404_page_content() {
+		return __( 'If you\'re lost or have reached this page in error, our apologies. Please use the navigation menu or the links in the footer to find your way through the site. Please e-mail us if you have any questions.', 'tribe' );
+	}
 }

--- a/wp-content/themes/core/404.twig
+++ b/wp-content/themes/core/404.twig
@@ -1,8 +1,17 @@
 {% extends "base.twig" %}
 
-{% block content %}
-	<div class="l-container">
-		<p>{{ lang['Houston, we have a problem...']|esc_html }}</p>
-	</div>
+{% block main %}
+
+	{% block subhead %}
+        {{ include( 'content/header/sub.twig' ) }}
+    {% endblock %}
+
+	{% block content %}
+		<div class="l-container">
+			<h2>{{ error_404_browser_title }}</h2>
+			<p>{{ error_404_browser_content }}</p>
+		</div>
+	{% endblock %}
+
 {% endblock %}
 


### PR DESCRIPTION
Issue: https://central.tri.be/issues/71371

This small update adds the following:

- Adds 404 messages to the controller
- Standardize 404 template to more closely match page template

I think we need some more discussion about how much we want to deviate from the standard page template layout for 404 and other error pages.  I'll leave a note in the ticket to follow up, but I think this small change would be helpful in the meantime.