### PR TITLE
Fix output directory for xdebug profiler

### DIFF
--- a/dev/docker/phpdocker/php-fpm/php-ini-overrides.ini
+++ b/dev/docker/phpdocker/php-fpm/php-ini-overrides.ini
@@ -5,7 +5,7 @@ xdebug.idekey="PHPSTORM"
 
 xdebug.profiler_enable=0
 xdebug.profiler_append=1
-xdebug.profiler_output_dir=/application/wp-content/uploads
+xdebug.profiler_output_dir=/application/www/wp-content/uploads
 xdebug.profiler_enable_trigger=1
 xdebug.profiler_output_name=cachegrind.out.%H.%R.%t
 


### PR DESCRIPTION
Noticed this wasn't pointing to the correct directory when I was trying to use the profiler.