### PR TITLE
adds mime_type for deciding to use width and height

### DIFF
--- a/wp-content/plugins/core/src/Theme/Image.php
+++ b/wp-content/plugins/core/src/Theme/Image.php
@@ -117,7 +117,6 @@ class Image {
 			$src_width  = $src[1];
 			$src_height = $src[2];
 			$src        = $src[0];
-			$this->options[ 'mime_type' ] = wp_check_filetype( $src );
 		}
 		$attrs[] = !empty( $this->options[ 'img_attr' ] ) ? trim( $this->options[ 'img_attr' ] ) : '';
 
@@ -187,11 +186,7 @@ class Image {
 			return false;
 		}
 
-		$no_size_mime_types = [
-			'image/svg',
-		];
-
-		return $this->options[ 'use_h&w_attr' ] && $this->options[ 'src' ] &&  ! in_array( $this->options['mime_type']['type'], $no_size_mime_types );
+		return $this->options[ 'use_h&w_attr' ] && $this->options[ 'src' ];
 	}
 
 	/**


### PR DESCRIPTION
This PR adds mime_type to the options array in Theme/Image. This allows us to conditionally not include height/width on image render for svg.
Looking for feedback and thoughts?
@ckpicker Can you add in whoever you want to review?