### PR TITLE
remove unsupported mem_limit property from docker-compose elasticsearch config

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -24,7 +24,6 @@ services:
         nofile:
           soft: 65536
           hard: 65536
-        mem_limit: 1g
       ports:
         - "9200"
       volumes:


### PR DESCRIPTION
Fixes a fatal error on startup with newer versions of docker.