### PR TITLE
COMPOSE_INTERACTIVE_NO_CLI env flag on compose exec

### DIFF
--- a/dev/docker/exec.sh
+++ b/dev/docker/exec.sh
@@ -14,4 +14,4 @@ else
 	DC_COMMAND="docker-compose"
 fi;
 
-${DC_COMMAND} --project-name=${PROJECT_ID} exec php-fpm "$@"
+COMPOSE_INTERACTIVE_NO_CLI=1 ${DC_COMMAND} --project-name=${PROJECT_ID} exec php-fpm "$@"


### PR DESCRIPTION
The docker-compose 1.19.0 update changed the behavior of the "run" and
"exec" commands. They now expect the docker cli to be available on the
client running the command, unless the COMPOSE_INTERACTIVE_NO_CLI flag
is set to 1 in the environment.

This allows, for example, PhpStorm to run the exec.sh script without
returning the error "the input device is not a TTY".

See https://github.com/docker/compose/releases/tag/1.19.0