### PR TITLE
Addresses new issue with icomoon sass vars that are unquoted.

### DIFF
--- a/grunt_options/replace.js
+++ b/grunt_options/replace.js
@@ -32,8 +32,8 @@ module.exports = {
 		options: {
 			patterns: [
 				{
-					match: /(\\[a-f0-9]+)/g,
-					replacement: '"$1"',
+					match: /(\\[a-f0-9]+);/g,
+					replacement: '"$1";',
 				},
 				{
 					match: /\$/g,


### PR DESCRIPTION
Solves an issue with new font exports from icomoon not have double quotes around the sass vars. This would output icon vars without the quotes in `/variables/_icons.pcss` thus breaking it. 

I've tested this and it works for me. However, there is likely a better RegEx patter here. Open to ideas.

I can also not confirm that this is a new bug from iconmoon that they might fix later.