### PR TITLE
Check if current screen exists before calling methods on it

### DIFF
--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -166,7 +166,7 @@ class Force_Plugin_Activation {
 		}
 
 		$screen = get_current_screen();
-		if ( $screen->in_admin( 'network' ) ) {
+		if ( $screen && $screen->in_admin( 'network' ) ) {
 			return $plugins;
 		}
 


### PR DESCRIPTION
Prevents a fatal error when running WP CLI commands