### PR TITLE
Add a changelog.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,21 +92,6 @@ GLOMAR is a plugin that blocks the frontend of the site from public access. If y
     define( 'TRIBE_GLOMAR', false );
 
 
-## Upgrade Notice
-
-= 1.1 =
-Moved the project dependencies to Composer  
-Added Codeception tests examples and instructions  
-= 1.0 =
-Initial Release
-
-
 ## Changelog
 
-
-= 1.1 =
-Moved the project dependencies to Composer  
-Added Codeception tests examples and instructions  
-= 1.0 =
-Initial Release
-
+[View changelog](./changelog.md)

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [1.2] - 2018-05-08
+
+A whole lot of things have been added. The timing of when they were added and the corresponding versions would be too laborious to uncover. So...we'll start with 1.2. Here are some recent changes/additions.
+
+### Added
+
+* Permissions Framework
+* TravisCI config file so tests get built when creating/updating a PR
+* Taxonomy List component
+
+### Changed
+
+* Switched to composer for WP rather than submoduling
+* Updated to webpack 4.5.0
+* Disable `SCRIPT_DEBUG` by default, enable for gardens
+* Remove GF WCAG and Regenerate plugins from version control
+* Fixed issue with the install path for composer
+* Synchronize VM time with system time when container starts
+* Use new 1.1.1.1 DNS instead of Google's
+
+## [1.1] - 2015-03-31
+
+### Added
+
+* Added Codeception test examples and instructions
+
+### Changed
+
+* Moved the project dependencies to Composer
+
+## [1.0] - ??
+
+### Added
+
+* Initial version


### PR DESCRIPTION
This changeset sets an initial version of 1.2. Three years ago there was the 1.1 version and a _lot_ has happened since then. My selection of 1.2 was just because it is an increase from the last stated version. If anyone feels strongly about calling the version something else, that works for me.

I also didn't attempt to summarize all of the changes in the past 3 years. Or even the past 3 months. I just hand selected a few token items to throw in the *Added* and the *Changed* sections. If we want to call out more things in those lists that are worthwhile, let's get them added.

Ultimately this is just to get us to a place where we can start tracking additions/changes/deletions and having awareness of what version of Square One that projects are running.

See: https://central.tri.be/issues/106088