### PR TITLE
Missing a forward slash for login css path

### DIFF
--- a/wp-content/plugins/core/src/Theme/Resources/Login_Resources.php
+++ b/wp-content/plugins/core/src/Theme/Resources/Login_Resources.php
@@ -9,7 +9,7 @@ class Login_Resources {
 	 */
 	public function login_styles() {
 
-		$css_dir = trailingslashit( get_stylesheet_directory_uri() ) . 'css/admin';
+		$css_dir = trailingslashit( get_stylesheet_directory_uri() ) . 'css/admin/';
 		$version = tribe_get_version();
 
 		// CSS


### PR DESCRIPTION
This fixes a small issue with the login styling not getting enqueued with the right path.  It was missing a forward slash.