### PR TITLE
WP Engine compatible Twig cache

### DIFF
--- a/wp-content/plugins/core/src/Service_Providers/Twig_Service_Provider.php
+++ b/wp-content/plugins/core/src/Service_Providers/Twig_Service_Provider.php
@@ -8,6 +8,7 @@ use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Tribe\Project\Templates;
 use Tribe\Project\Twig\Extension;
+use Tribe\Project\Twig\Twig_Cache;
 
 class Twig_Service_Provider implements ServiceProviderInterface {
 	public function register( Container $container ) {
@@ -23,14 +24,15 @@ class Twig_Service_Provider implements ServiceProviderInterface {
 		};
 
 		$container[ 'twig.cache' ] = function ( Container $container ) {
-			return WP_CONTENT_DIR . '/cache/twig';
+			return new Twig_Cache( WP_CONTENT_DIR . '/cache/twig/' );
 		};
 
 		$container[ 'twig.options' ] = function ( Container $container ) {
 			return apply_filters( 'tribe/project/twig/options', [
-				'debug'      => WP_DEBUG,
-				'cache'      => $container[ 'twig.cache' ],
-				'autoescape' => false,
+				'debug'         => WP_DEBUG,
+				'cache'         => $container[ 'twig.cache' ],
+				'autoescape'    => false,
+				'auto_reload'   => true,
 			] );
 		};
 

--- a/wp-content/plugins/core/src/Twig/Twig_Cache.php
+++ b/wp-content/plugins/core/src/Twig/Twig_Cache.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tribe\Project\Twig;
+
+class Twig_Cache extends \Twig_Cache_Filesystem {
+	protected $path;
+
+	public function __construct( $path, $options = 0 ) {
+		$this->path = $path;
+		parent::__construct( $path, $options );
+	}
+
+	public function generateKey( $name, $className ) {
+		$hash = hash( 'sha256', $className );
+
+		return $this->path . $hash[ 0 ] . $hash[ 1 ] . '/' . $hash . '.html';
+	}
+}


### PR DESCRIPTION
Based on work @msawicki did and then reused in AAA. This cache is compatible with WP Engine but can be used in any environment... so it should be in Square One.