### PR TITLE
Fix issues where this regex is running on content without images and …

### DIFF
--- a/wp-content/plugins/core/src/Theme/Image_Wrap.php
+++ b/wp-content/plugins/core/src/Theme/Image_Wrap.php
@@ -19,6 +19,11 @@ class Image_Wrap {
 			return $html;
 		}
 
+		// first check if any image tags exist in the content before filtering
+		if( ! $this->content_has_image( $html ) ) {
+			return $html;
+		}
+
 		return preg_replace_callback( '/<p>((?:.(?!p>))*?)(<a[^>]*>)?\s*(<img[^>]+>)(<\/a>)?(.*?)<\/p>/is', function( $matches ) {
 
 			/*
@@ -112,5 +117,20 @@ class Image_Wrap {
 		];
 
 		return preg_replace( $patterns, $replacements, $html );
+	}
+
+	/**
+	 * Check if content has any image tags
+	 *
+	 * @param string $html
+	 *
+	 * @return bool
+	 */
+	private function content_has_image( $html = '' ): bool {
+		if( stristr( $html, '<img' ) !== false ) {
+			return true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
Client in LL found a weird bug where if you enter a string of numbers (1-1000 for example) content would no longer display. I tracked it down to the this regex, but not sure where it's failing but simply checking if an `<img` is in the content before running it allows everything to work.