### PR TITLE
Force Gravity Forms HTML5 and disable inline CSS

### DIFF
--- a/wp-content/plugins/core/src/Theme/Gravity_Forms_Filter.php
+++ b/wp-content/plugins/core/src/Theme/Gravity_Forms_Filter.php
@@ -28,6 +28,8 @@ class Gravity_Forms_Filter {
 		add_filter( 'gform_pre_render', [ $this, 'deactivate_gf_animations' ] );
 		add_filter( 'gform_confirmation_anchor', '__return_false' );
 		add_filter( 'gform_tabindex', '__return_false' );
+		add_filter( 'pre_option_rg_gforms_disable_css', '__return_true' );
+		add_filter( 'pre_option_rg_gforms_enable_html5', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
While I'm thinking about it, @ryanurban requested this get put into Square One. It disables inline CSS and forces HTML5.

See: https://github.com/moderntribe/aaa-national/pull/68#commitcomment-29103675