### PR TITLE
set a time limit on queue consumer execution

### DIFF
--- a/wp-content/plugins/core/src/CLI/Queues/Process.php
+++ b/wp-content/plugins/core/src/CLI/Queues/Process.php
@@ -12,6 +12,13 @@ class Process extends Command {
 	 */
 	protected $queues;
 
+	/**
+	 * @var int How long the process should run, in seconds. If 0,
+	 *          the process will run until it meets a fatal error
+	 *          (e.g., out of memory).
+	 */
+	private $timelimit = 300;
+
 	public function __construct( Queue_Collection $queue_collection ) {
 		$this->queues = $queue_collection;
 		parent::__construct();
@@ -53,8 +60,10 @@ class Process extends Command {
 			\WP_CLI::error( $e->getMessage() );
 		}
 
+		$endtime = time() + $this->timelimit;
+
 		// Run forever.
-		while ( 1 ) {
+		while ( $endtime === 0 || time() < $endtime ) {
 
 			// If the queue is empty, sleep on it and then clear it again.
 			if ( ! $queue->count() ) {


### PR DESCRIPTION
Long running WP processes, even in CLI, tend to run into memory issues and cache corruption issues. The queue consumer is no exception. Over time, it will consume more and more memory until it reaches the limit and dies.

This sets a limit of 300 seconds (five minutes). In theory, a cron job would re-spawn a consumer every 5 minutes to pick up where it left off.