### PR TITLE
fix broken cleanup task, also remove completed items

### DIFF
--- a/wp-content/plugins/core/src/Queues/Contracts/Queue.php
+++ b/wp-content/plugins/core/src/Queues/Contracts/Queue.php
@@ -43,4 +43,14 @@ abstract class Queue {
 		$this->backend->nack( $job_id, $this->get_name() );
 	}
 
+	/**
+	 * Pass the cleanup request on to the backend that knows
+	 * how to handle it.
+	 *
+	 * @return void
+	 */
+	public function cleanup() {
+		$this->backend->cleanup();
+	}
+
 }

--- a/wp-content/plugins/core/src/Queues/Queue_Collection.php
+++ b/wp-content/plugins/core/src/Queues/Queue_Collection.php
@@ -16,6 +16,11 @@ class Queue_Collection {
 		return $this->instances;
 	}
 
+	/**
+	 * @param string $queue_name
+	 *
+	 * @return Queue
+	 */
 	public function get( $queue_name ) {
 		if ( isset( $this->instances[ $queue_name ] ) ) {
 			return $this->instances[ $queue_name ];


### PR DESCRIPTION
The cleanup task was calling an undefined method. With that fixed, it was resetting items that had been claimed up to five minutes in the future.

This fixes the above bugs, and also removes completed items from the queue after five minutes.