### PR TITLE
Update gitignore to not ignore the pcss vendor dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,6 @@ dev/docker/mysql/*
 !dev/docker/mysql/.gitkeep
 wp-content/themes/core/css
 wp-content/themes/core/js/dist
-vendor/
 
 # WP Engine #
 #############
@@ -114,7 +113,6 @@ wp-content/plugins/airplane-mode
 **/__coverage__/
 dev_components/react-app/test/__coverage__/
 dev/deploy/.deploy
-!core/pcss/vendor/
 
 # DevOps #
 #######################


### PR DESCRIPTION
On some new projects I noticed that the `pcss/vendor` dir was being gitignored, and we don't want this.  This PR fixes that, but keeps other `vendor` dirs ignored to play nicely with composer.