### PR TITLE
Updates post loop controller to support custom content

### DIFF
--- a/wp-content/plugins/core/src/Templates/Content/Panels/PostLoop.php
+++ b/wp-content/plugins/core/src/Templates/Content/Panels/PostLoop.php
@@ -110,7 +110,7 @@ class PostLoop extends Panel {
 
 	protected function get_post_button( $post_link ) {
 		$options = [
-			Button::URL         => esc_url( $post_link ),
+			Button::URL         => esc_url( $post_link[ 'url' ] ),
 			Button::LABEL       => __( 'View Post', 'tribe' ),
 			Button::TARGET      => '_self',
 			Button::BTN_AS_LINK => true,


### PR DESCRIPTION
I was recently working on a post loop panel and noticed that titles/links for custom content weren't displaying correctly.  This PR addresses that.