### PR TITLE
Video Panel - dial-in oembed for default video panel

### DIFF
--- a/wp-content/plugins/core/src/Templates/Content/Panels/VideoText.php
+++ b/wp-content/plugins/core/src/Templates/Content/Panels/VideoText.php
@@ -10,7 +10,6 @@ use Tribe\Project\Templates\Components\Video;
 use Tribe\Project\Templates\Components\Text;
 use Tribe\Project\Templates\Components\Title;
 use Tribe\Project\Theme\Util;
-use Tribe\Project\Facade\Items\Theme\Oembed;
 
 class VideoText extends Panel {
 


### PR DESCRIPTION
Ensure that the default video text panel can handle oembed. Piggyback off the OEmbed_Filter functions for extracting the youtube/vimeo IDs. Then render out the video component with all of it features (thumbnail, title, play text, etc). 