### PR TITLE
Include build process file in wp-config.php

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -36,6 +36,14 @@ if ( file_exists( __DIR__ . '/.env' ) ) {
 }
 
 // ==============================================================
+// Load build process timestamp
+// ==============================================================
+
+if ( file_exists( dirname( __FILE__ ) . '/build-process.php' ) ) {
+	include( dirname( __FILE__ ) . '/build-process.php' );
+}
+
+// ==============================================================
 // Load database info and local development parameters
 // ==============================================================
 


### PR DESCRIPTION
This includes by default the build-process.php file that contains the FE asset timestamp as part of wp-config.php for cache busting