### PR TITLE
Agency Codesniffs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Theme Coding Standards">
+    <description>A custom ruleset to take in account both WordPress and Modern Tribe code standards.</description>
+    <file>./wp-content/plugins/core/src</file>
+
+    <exclude-pattern>*/.git/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>*.css</exclude-pattern>
+
+    <rule ref="WordPress-Extra">
+        <exclude name="PSR2.ControlStructures.ElseIfDeclaration" />
+        <exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions" />
+        <exclude name="WordPress.Files.FileName" />
+        <exclude name="WordPress.PHP.YodaConditions" />
+        <exclude name="WordPress.NamingConventions" />
+        <exclude name="Generic.Formatting.MultipleStatementAlignment" />
+        <exclude name="WordPress.WP.EnqueuedResourceParameters" />
+        <exclude name="Generic.Files.EndFileNewline.NotFound" />
+        <exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
+        <exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
+        <exclude name="Squiz.Operators.IncrementDecrementUsage.NoBrackets" />
+        <exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found" />
+        <exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
+    </rule>
+
+    <!-- Ensure no empty statements -->
+    <rule name="Generic.CodeAnalysis.EmptyStatement"/>
+
+    <!-- Do not allow @todo notations to stay -->
+    <rule ref="Generic.Commenting.Todo"/>
+
+    <!-- Warn if methods are not docblock commented. We're trying to do better here -->
+    <rule name="Squiz.Commenting.FunctionComment.Missing">
+        <severity>1</severity>
+    </rule>
+
+    <rule ref="Internal.NoCodeFound">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Checks that the opening brace of a function is on the line of the function declaration. -->
+    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
+
+    <!-- Ensures that constant names are all uppercase. -->
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+
+    <!-- Discourages the use of deprecated functions that are kept in PHP for compatibility with older versions.  -->
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+
+    <!-- Discourages the use of alias functions that are kept in PHP for compatibility with older versions. Can be used to forbid the use of any function. -->
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+
+    <!-- PHP keywords MUST be in lower case -->
+    <rule ref="Generic.PHP.LowerCaseKeyword"/>
+
+    <!-- The PHP constants true, false, and null MUST be in lower case. -->
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
+
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
+        <severity>0</severity>
+    </rule>
+
+    <!-- There MUST NOT be trailing whitespace at the end of non-blank lines. -->
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
+        <severity>0</severity>
+    </rule>
+
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Visibility MUST be declared on all methods. -->
+    <rule ref="Squiz.Scope.MethodScope"/>
+    <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
+
+    <!-- Checks for usage of "$this" in static methods, which will cause runtime errors. -->
+    <rule ref="Squiz.Scope.StaticThisUsage"/>
+
+    <!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
+    <rule ref="Zend.Files.ClosingTag"/>
+
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+</ruleset>


### PR DESCRIPTION
Replacement for this PR, which had a lot of attempted "fixes" to Square1. https://github.com/moderntribe/square-one/pull/271

Task: https://central.tri.be/issues/118008

This is a first attempt at creating a common sense PHP Codesniffer ruleset for Square1 and Agency projects. It might not be exhaustive and it might be too strict. Looking for feedback here.

Configuring PHPCS guide: https://www.jetbrains.com/help/phpstorm/using-php-code-sniffer-tool.html#enablingCodeSniffer

Configuring Inspections: http://p.tri.be/gc4uxg

Configuring PHPCS in phpStorm: http://p.tri.be/hvjm6n