### PR TITLE
Only prevent the insertion of the hello world comment but allow others

### DIFF
--- a/wp-content/plugins/core/src/Syndicate/Blog.php
+++ b/wp-content/plugins/core/src/Syndicate/Blog.php
@@ -317,10 +317,7 @@ class Blog {
 			$query = 'SELECT 0';
 		}
 
-		if (
-			false !== strpos( $query, "INSERT INTO `{$wpdb->comments}` (`comment_post_ID`, `comment_author`, " )
-			&& false !== strpos( $query, 'VALUES ( 1' )
-		) {
+		if ( $this->is_hello_world_comment_query( $query ) ) {
 			$query = 'SELECT 0';
 		}
 
@@ -384,5 +381,24 @@ class Blog {
 
 		$sql = $wpdb->prepare( "DELETE FROM {$wpdb->base_prefix}syndicated_posts WHERE blog_id=%d", $blog_id );
 		$wpdb->query( $sql );
+	}
+
+	/**
+	 * Determines if a comment is a default comment added on blog creation
+	 *
+	 * @param string $query
+	 *
+	 * @return bool
+	 */
+	private function is_hello_world_comment_query( $query ) {
+		if ( false === strpos( $query, "INSERT INTO `{$wpdb->comments}` (`comment_post_ID`, `comment_author`, " ) ) {
+			return false;
+		}
+
+		if ( false === strpos( $query, 'VALUES ( 1' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
This fix enables the ability to add comments to a post in a multisite install with syndication enabled. Without this change, the `enforce_insertion_id()` method changes _any_ `INSERT` statement for comments into `SELECT 0`.

Found while doing a bugfix on AAA.