### PR TITLE
Check for footer scripts existence before check for its value.

### DIFF
--- a/wp-content/plugins/core/src/Theme/Resources/Scripts.php
+++ b/wp-content/plugins/core/src/Theme/Resources/Scripts.php
@@ -39,7 +39,7 @@ class Scripts {
 			$script = $wp_scripts->registered[ $handle ];
 
 			//-- Weird way to check if script is being enqueued in the footer.
-			if ( $script->extra[ 'group' ] === 1 ) {
+			if ( isset( $script->extra[ 'group' ] ) && $script->extra[ 'group' ] === 1 ) {
 
 				//-- If version is set, append to end of source.
 				$source = $script->src . ( $script->ver ? "?ver={$script->ver}" : "" );


### PR DESCRIPTION
Added a check for the group scripts key existence before a check for its value. This was causing the front end to show a annoying notice for the undefined "group" index.