### PR TITLE
Add WP_DISABLE_FATAL_ERROR_HANDLER to config to disable fatal error handler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * Changed: Updated default PHP version to 7.2
 * Changed: Added in default Panels Caching
 * Changed: Added in Whoops library
+* Add `WP_DISABLE_FATAL_ERROR_HANDLER` constant to wp-config to disable the fatal error handler
 
 ## [2019.03]
 

--- a/wp-config.php
+++ b/wp-config.php
@@ -126,14 +126,15 @@ $config_defaults = [
 	'FILE_CACHE_MAX_FILE_AGE' => 315000000, // about 10 years
 
 	// Debug
-	'WP_DEBUG'                => tribe_getenv( 'WP_DEBUG', true ),
-	'WP_DEBUG_LOG'            => tribe_getenv( 'WP_DEBUG_LOG', true ),
-	'WP_DEBUG_DISPLAY'        => tribe_getenv( 'WP_DEBUG_DISPLAY', true ),
-	'SAVEQUERIES'             => tribe_getenv( 'SAVEQUERIES', true ),
-	'SCRIPT_DEBUG'            => tribe_getenv( 'SCRIPT_DEBUG', false ),
-	'CONCATENATE_SCRIPTS'     => tribe_getenv( 'CONCATENATE_SCRIPTS', false ),
-	'COMPRESS_SCRIPTS'        => tribe_getenv( 'COMPRESS_SCRIPTS', false ),
-	'COMPRESS_CSS'            => tribe_getenv( 'COMPRESS_CSS', false ),
+	'WP_DEBUG'                       => tribe_getenv( 'WP_DEBUG', true ),
+	'WP_DEBUG_LOG'                   => tribe_getenv( 'WP_DEBUG_LOG', true ),
+	'WP_DEBUG_DISPLAY'               => tribe_getenv( 'WP_DEBUG_DISPLAY', true ),
+	'SAVEQUERIES'                    => tribe_getenv( 'SAVEQUERIES', true ),
+	'SCRIPT_DEBUG'                   => tribe_getenv( 'SCRIPT_DEBUG', false ),
+	'CONCATENATE_SCRIPTS'            => tribe_getenv( 'CONCATENATE_SCRIPTS', false ),
+	'COMPRESS_SCRIPTS'               => tribe_getenv( 'COMPRESS_SCRIPTS', false ),
+	'COMPRESS_CSS'                   => tribe_getenv( 'COMPRESS_CSS', false ),
+	'WP_DISABLE_FATAL_ERROR_HANDLER' => tribe_getenv( 'WP_DISABLE_FATAL_ERROR_HANDLER', true ),
 
 	// Domain Mapping
 	//'SUNRISE'                 => true,


### PR DESCRIPTION
Per https://make.wordpress.org/core/2019/04/16/fatal-error-recovery-mode-in-5-2/, the constant `WP_DISABLE_FATAL_ERROR_HANDLER` can be set to disable the fatal error handler built into WordPress 5.2+.

We want this disabled:

* Locally, because we'll often have transitory fatal errors while we're working, and it will be annoying if WP keeps disabling plugins on us.
* In dev/staging, because we want to see the fatal errors and fix them, and we want a consistent and predictable environment for QA.
* In production, because an unexpectedly disabled plugin could cause data corruption, expose security vulnerabilities, or worse.