### PR TITLE
Update install-guide-for-ubuntu.md

### DIFF
--- a/docs/docker/install-guide-for-ubuntu.md
+++ b/docs/docker/install-guide-for-ubuntu.md
@@ -119,17 +119,12 @@ npm install -g grunt-cli
 	sudo apt-get install docker-ce
 	```
 
-    7. Install Docker Snap
-	```
-	sudo snap install docker.
-	```
-
-    8. Verify that Docker CE is installed correctly by running the hello-world image.
+    7. Verify that Docker CE is installed correctly by running the hello-world image.
 	```
 	sudo docker run hello-world
 	```
 
-    9. There seems to be an issue with docker and permissions, so executing the following command will save you from that headache. [View source](https://github.com/docker/compose/issues/4181)
+    8. There seems to be an issue with docker and permissions, so executing the following command will save you from that headache. [View source](https://github.com/docker/compose/issues/4181)
 	```
 	sudo usermod -aG docker $USER
 	```


### PR DESCRIPTION
There's no need to install `docker` as a snap package, since `sudo apt-get install docker-ce` already contains both the daemon and the client.

Installing the client again with snap might cause conflicts: https://unix.stackexchange.com/questions/525139/docker-only-connects-to-daemon-after-restart/525140