### PR TITLE
use mariadb instead of mysql

### DIFF
--- a/dev/docker/global/docker-compose.yml
+++ b/dev/docker/global/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         ipv4_address: 172.20.10.250
 
   mysql:
-    image: mysql:5.7
+    image: mariadb:10
     container_name: tribe-mysql
     volumes:
       - ${TRIBE_MYSQL_DATA_DIR:-~/mysql_data}:/var/lib/mysql


### PR DESCRIPTION
Updates the global container to use MariaDB instead of MySQL.

After updating your local environment, a migration command is required:

```
docker exec -it tribe-mysql /bin/bash -c "mysql_upgrade -uroot -ppassword"
```

Otherwise MariaDB will throw some warnings at you (if you're looking in the logs).