### PR TITLE
set PAGER environment variable

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       environment:
         - COMPOSER_ALLOW_SUPERUSER=1
         - COMPOSER_CACHE_DIR=/application/composer-cache
+        - PAGER=more
 
     webserver:
       image: nginx:stable-alpine


### PR DESCRIPTION
Sets the `PAGER` environment variable to `more` so that WP CLI commands that use the pager don't complain when `less` isn't available.

```
sh: 1: less: not found
```

Alternatively, we could just add `less` to our `Dockerfile`. I don't particularly have a preference between the two approaches.

Re-opens https://github.com/moderntribe/square-one/pull/338