### PR TITLE
Issue #362: TravisCI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ env:
     - TEST_DB_NAME="tribe_square1_tests"
     - WP_ADMIN_USERNAME="admin"
     - WP_ADMIN_PASSWORD="password"
-    # Secure travis token resolves to `CI_USER_TOKEN='key'` and is used in dev/docker/start.sh to add credentials to composer-config.json
-    # Token is a personal access token for tr1b0t
-    - secure: Hn0zgFdCufW8MQBuzy1ZvSSRrSwGaxGJal+d9Dd+uHExd81P50OBYcGlVMKga4tn2MkE3wNFUtgWJXb7Qy7h3Reu4+X5FqFAY3kjmSsXdXXn6jVw0r29LQo4boCbZLfT+9flvocaVmgUwwfDjPGwQTg58ZD7MdW7NEiCzppenxM=
 before_install:
   - sudo service mysql stop
 

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       environment:
         - COMPOSER_ALLOW_SUPERUSER=1
         - COMPOSER_CACHE_DIR=/application/composer-cache
+        - WP_PLUGIN_ACF_KEY=${WP_PLUGIN_ACF_KEY:-''}
+        - WP_PLUGIN_GF_KEY=${WP_PLUGIN_GF_KEY:-''}
 
     webserver:
       image: nginx:stable-alpine

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,3 +1,6 @@
 # Deployment
 
 TODO - Describe how to manually deploy SQ1 as well as the deployment tools baked in.
+
+## Table of Contents
+[TravisCI](./travisCI.md)

--- a/docs/deployment/travisCI.md
+++ b/docs/deployment/travisCI.md
@@ -1,0 +1,32 @@
+# TravisCI
+
+SquareOne includes a configuration file for continuous integration with TravisCI. Access the [TravisCI Dashboard](https://travis-ci.com/dashboard) to view your build progress.
+
+## Setting up a new project
+
+The first time you log into TCI, you'll need to use your personal GitHub account to authorize access. After doing so, you'll see a dashboard of projects across Tribe.
+
+Setting up TravisCI for your project requires you to set three environmental variables: 
+
+* `CI_USER_TOKEN`: A GitHub oAuth token. Please see [Creating an oAuth app](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) for instructions on how to do this.
+* `WP_PLUGIN_ACF_KEY`: The product key for ACF used by composer to install the plugin. Find this in 1Password.
+* `WP_PLUGIN_GF_KEY`: The product key for GravityForms used by composer to install  the plugin. Find this in 1Password.
+
+To set these up, navigate to your project's CI page (it should have a URL like this: https://travis-ci.com/moderntribe/your-amazing-project), and click on More Options-> Settings in the top right.
+
+Finally, find the Environment Variables section and add these one-by-one. Be sure not to display these in the build log!
+
+## Adding other environmental variables
+
+You may find you need to use other env variables in your Docker containers. To add these, you will need to follow the steps in [the section above](#setting-up-a-new-project), and then make them available to Docker Compose.
+
+To do that, find your project's `docker-compose.yml` file in `dev/docker/`, and add them to the relevant container's `environment` entry, as shown:
+
+```yaml
+...
+environment:
+    - SOME_CONST=${SOME_CONST:-''}
+...
+```
+
+_Note: The syntax `:-''` tells Compose that if the variable is not set, use an empty string. Replace this with whatever default value you'd like._


### PR DESCRIPTION
I added some constants to the Docker Compose file's environment section and removed the tr1b0t oAuth token from travis.yml. You need to set this manually for the project in the TravisCI settings now, which is covered in the included documentation.

Please take note that the secret has been removed from the travisCI config-- this may cause unconfigured builds to begin to fail.