### PR TITLE
Bugfix/Include swiper with vendor JS

### DIFF
--- a/gulp_tasks/uglify.js
+++ b/gulp_tasks/uglify.js
@@ -12,6 +12,7 @@ module.exports = {
 			`${ pkg._core_theme_js_vendor_path }ls.respimg.js`,
 			`${ pkg._core_theme_js_vendor_path }ls.bgset.js`,
 			`${ pkg._core_theme_js_vendor_path }lazysizes.js`,
+			`${ pkg._core_theme_js_vendor_path }swiper.js`,
 		] )
 			.pipe( concat( 'vendorGlobal.min.js' ) )
 			.pipe( uglify( {


### PR DESCRIPTION
Updates gulp uglify task so that Swiper library is included in the vendor JS file. Without this, Swiper JS doesn't load for environments with `SCRIPT_DEBUG` set to false. 

More context in Slack, here: https://tribe.slack.com/archives/C02595YKF/p1567557114007700