### PR TITLE
Feature/improved search

### DIFF
--- a/wp-content/plugins/core/src/Templates/Base.php
+++ b/wp-content/plugins/core/src/Templates/Base.php
@@ -155,7 +155,6 @@ class Base extends Twig_Template {
 	protected function submit_button(): string {
 
 		$btn_attr = [
-			'type'  => 'submit',
 			'name'  => 'submit',
 			'value' => __( 'Search', 'tribe' ),
 		];
@@ -164,6 +163,7 @@ class Base extends Twig_Template {
 			Button::LABEL   => __( 'Search', 'tribe' ),
 			Button::CLASSES => [ 'c-button' ],
 			Button::ATTRS   => $btn_attr,
+			Button::TYPE    => 'submit',
 		];
 
 		$button = Button::factory( $options );

--- a/wp-content/plugins/core/src/Templates/Search.php
+++ b/wp-content/plugins/core/src/Templates/Search.php
@@ -4,10 +4,37 @@
 namespace Tribe\Project\Templates;
 
 class Search extends Index {
+
+	public function get_data(): array {
+		$data                   = parent::get_data();
+		$data['search_details'] = $this->get_search_details( count( $data['posts'] ) );
+
+		return $data;
+	}
+
 	protected function get_single_post() {
 		$template = new Content\Search\Search( $this->template, $this->twig );
-		$data    = $template->get_data();
+		$data     = $template->get_data();
 
-		return $data[ 'post' ];
+		return $data['post'];
+	}
+
+	protected function get_search_details( int $posts_found ): array {
+		$query = get_search_query();
+
+		$result_text = _n(
+			'result',
+			'results',
+			$posts_found,
+			'tribe'
+		);
+
+		$search_details = [
+			'query'   => esc_html( $query ),
+			'results' => esc_html( $result_text ),
+			'count'   => $posts_found,
+		];
+
+		return $search_details;
 	}
 }

--- a/wp-content/plugins/core/src/Templates/Search.php
+++ b/wp-content/plugins/core/src/Templates/Search.php
@@ -7,7 +7,7 @@ class Search extends Index {
 
 	public function get_data(): array {
 		$data                   = parent::get_data();
-		$data['search_details'] = $this->get_search_details( count( $data['posts'] ) );
+		$data['search_details'] = $this->get_search_details();
 
 		return $data;
 	}
@@ -19,8 +19,15 @@ class Search extends Index {
 		return $data['post'];
 	}
 
-	protected function get_search_details( int $posts_found ): array {
-		$query = get_search_query();
+	protected function get_search_details(): array {
+		global $wp_query;
+
+		if ( ! $wp_query instanceof \WP_Query ) {
+			return [];
+		}
+
+		$posts_found = $wp_query->found_posts;
+		$query       = get_search_query();
 
 		$result_text = _n(
 			'result',

--- a/wp-content/themes/core/content/search/search-result-count.twig
+++ b/wp-content/themes/core/content/search/search-result-count.twig
@@ -1,0 +1,5 @@
+<aside class="search-result-count">
+
+    <p class="search-result-count__content">Your search for "{{ search_details.query }}" returned {{ search_details.count }} {{ search_details.results }}</p>
+
+</aside>

--- a/wp-content/themes/core/search.twig
+++ b/wp-content/themes/core/search.twig
@@ -2,7 +2,10 @@
 
 {% block content %}
 	<div class="l-container">
-		{{ include( 'content/search/search-result-count.twig' ) }}
+		{% if search_details is not empty %}
+			{{ include( 'content/search/search-result-count.twig' ) }}
+		{% endif %}
+
 		{% if posts|length > 0 %}
 			{% for post in posts %}
 				{{ include( 'content/search/search.twig') }}

--- a/wp-content/themes/core/search.twig
+++ b/wp-content/themes/core/search.twig
@@ -2,13 +2,12 @@
 
 {% block content %}
 	<div class="l-container">
+		{{ include( 'content/search/search-result-count.twig' ) }}
 		{% if posts|length > 0 %}
 			{% for post in posts %}
 				{{ include( 'content/search/search.twig') }}
 			{% endfor %}
 			{{ include( 'content/pagination/loop.twig') }}
-		{% else %}
-			{{ include( 'content/no-results.twig' ) }}
 		{% endif %}
 	</div>
 {% endblock %}


### PR DESCRIPTION
While working on a new S1 project, I've stumbled upon a thing or two that I personally think would make sense to port to S1 as default. I'll just make the PR and let you decide that :rocket: :rocket: 

### Fix: Search button not working (https://github.com/moderntribe/square-one/commit/5369e872f2c8b7f988f1bae188233e30b9a98e28)
On a default S1 installation, clicking the search button does not trigger a search because "type=submit" is missing from the button attributes


### Improving search when no results found (https://github.com/moderntribe/square-one/commit/a88a2fc791d33f2fa4399624322bbd1f1890ac80)
By default on S1, the same template handles an empty archive of posts, (index.twig) and a search form where no results were found.

This commit aims to improve the defaults to a more sensible behavior, as seen on these screenshots:

| Before  | After with results | After without results |
| ------------- | ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/9341686/66506122-1be3e600-eaa3-11e9-9352-198b17e3d909.png)  | ![image](https://user-images.githubusercontent.com/9341686/66506187-3ddd6880-eaa3-11e9-94cd-114df9c8b928.png)  | ![image](https://user-images.githubusercontent.com/9341686/66506200-43d34980-eaa3-11e9-8a73-6b479a05525d.png) |


