### PR TITLE
Add container component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-
+## 2019.11
+* Added container component to allow for more composition flexibility
 ## 2019.10
 * Changed: Updated core plugin to work with the Tribe Libs monorepo
 * Changed: Loosened version constrain on Tribe Libs packages to "^2.0"

--- a/wp-content/plugins/core/src/Templates/Components/Container.php
+++ b/wp-content/plugins/core/src/Templates/Components/Container.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tribe\Project\Templates\Components;
+
+class Container extends Component {
+
+	const TEMPLATE_NAME = 'components/container.twig';
+	const CONTENT       = 'content';
+	const TAG           = 'tag';
+	const CLASSES       = 'classes';
+	const ATTRS         = 'attrs';
+
+	protected function parse_options( array $options ): array {
+		$defaults = [
+			static::CONTENT => '',
+			static::TAG     => 'div',
+			static::CLASSES => [ 'c-container' ],
+			static::ATTRS   => [],
+		];
+
+		return wp_parse_args( $options, $defaults );
+	}
+
+	public function get_data(): array {
+		$data = [
+			static::CONTENT => $this->options[ static::CONTENT ],
+			static::TAG     => $this->options[ static::TAG ],
+			static::CLASSES => $this->merge_classes( [], $this->options[ static::CLASSES ], true ),
+			static::ATTRS   => $this->merge_attrs( [], $this->options[ static::ATTRS ], true ),
+		];
+
+		return $data;
+	}
+}

--- a/wp-content/themes/core/components/container.twig
+++ b/wp-content/themes/core/components/container.twig
@@ -1,0 +1,20 @@
+{#
+
+Component: Container
+
+Controller: wp-content\plugins\core\src\Templates\Components\Container.php
+
+Description: A component to contain arbitrary html and take classes/attributes. Useful when composing more complex ui's in other controllers
+
+Attributes:
+	{
+		classes: '', // string. The container classes
+		tag: '', // string. The tagname for the container
+		content: '', // string. The content to be contained
+		attrs: '', // string. Data attributes for the container
+    }
+ #}
+
+<{{ tag }} class="{{ classes }}" {{ attrs }}>
+	{{ content }}
+</{{ tag }}>


### PR DESCRIPTION
Added container component. I found myself needing a simple wrapper component that can take aribtrary html and have a custom tag, classes and attributes. It allows me to compose more complex ui's in controllers while following our rule of no html strings in controllers, which i have seen happening in some places around projects. An example usage from a reasonably complex hero panel/slider i had to compose, the slide creator:

```php
/**
	 * Composes a hero pane, either for use in the slider or for use on its own.
	 *
	 * @param array $data
	 * @param int $index
	 * @return string
	 */

	protected function get_slide( $data = [], $index = 0 ): string {
		$left_html = $this->get_left_rail_image( $data );
		$left_html .= $this->get_left_image( $data[ HeroPanel::FIELD_SLIDE_IMAGE ] );

		$right_html = $this->get_right_content( $data, $index );
		$right_html .= $this->get_right_image( $data[ HeroPanel::FIELD_SLIDE_RIGHT_IMAGE ] );

		$left_container_options = [
			Container::CLASSES => [ 'hero__left' ],
			Container::CONTENT => $left_html,
		];

		$right_container_options = [
			Container::CLASSES => [ 'hero__right' ],
			Container::CONTENT => $right_html,
		];

		$left_container  = Container::factory( $left_container_options )->render();
		$right_container = Container::factory( $right_container_options )->render();

		$wrapper_options = [
			Container::TAG     => 'article',
			Container::CLASSES => [ 'hero__pane' ],
			Container::CONTENT => sprintf( '%s%s', $left_container, $right_container ),
		];

		$wrapper_container = Container::factory( $wrapper_options );

		return $wrapper_container->render();
	}
```