### PR TITLE
Optimize dev flows for no react

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-
+## 2019.11
+* Added ifdef loader for Webpack to allow exclusion of React app chunk generation during main js bundle dev work
 ## 2019.10
 * Changed: Updated core plugin to work with the Tribe Libs monorepo
 * Changed: Loosened version constrain on Tribe Libs packages to "^2.0"

--- a/gulp_tasks/watch.js
+++ b/gulp_tasks/watch.js
@@ -11,6 +11,32 @@ const watchConfig = {
 	watch: true,
 };
 
+const ifdefOpts = {
+	'INCLUDEREACT': false,
+	'version': 3,
+	'ifdef-verbose': true,
+	'ifdef-triple-slash': false,
+};
+
+const ifDefRuleOverride = [
+	{
+		test: /\.js$/,
+		exclude: [ /(node_modules)/ ],
+		use: [
+			{
+				loader: 'babel-loader',
+			},
+			{
+				loader: 'ifdef-loader',
+				options: ifdefOpts,
+			},
+		],
+	},
+];
+
+webpackAdminDevConfig.module.rules = ifDefRuleOverride;
+webpackThemeDevConfig.module.rules = ifDefRuleOverride;
+
 function maybeReloadBrowserSync() {
 	const server = browserSync.get( 'Tribe Dev' );
 	if ( server.active ) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:e2e": "cross-env NODE_ENV=test npx cypress run",
     "codecept": "dev/docker/exec.sh /application/www/dev/docker/codecept.sh",
     "codecept:test": "dev/docker/exec.sh /application/www/dev/docker/codecept.sh run",
+    "codecept:libs": "./dev/docker/exec.sh /application/www/dev/docker/codecept.sh -c /application/www/vendor/moderntribe/tribe-libs/tests/",
     "docker:start": "./dev/docker/start.sh",
     "docker:stop": "./dev/docker/stop.sh",
     "docker:log": "./dev/docker/log.sh",
@@ -53,9 +54,7 @@
     "docker:global:start": "./dev/docker/global/start.sh",
     "docker:global:stop": "./dev/docker/global/stop.sh",
     "docker:global:log": "./dev/docker/global/log.sh",
-    "docker:global:cert": "./dev/docker/global/cert.sh",
-    "codecept": "./dev/docker/exec.sh /application/www/dev/docker/codecept.sh",
-    "codecept:libs": "./dev/docker/exec.sh /application/www/dev/docker/codecept.sh -c /application/www/vendor/moderntribe/tribe-libs/tests/"
+    "docker:global:cert": "./dev/docker/global/cert.sh"
   },
   "resolutions": {
     "babel-core": "^7.0.0-bridge.0"
@@ -152,6 +151,7 @@
     "gulp-stylelint": "^7.0.0",
     "gulp-uglify": "^3.0.1",
     "identity-obj-proxy": "^3.0.0",
+    "ifdef-loader": "^2.1.1",
     "jest": "^23.6.0",
     "jest-environment-jsdom": "^23.4.0",
     "jest-environment-jsdom-global": "^1.1.1",

--- a/wp-content/themes/core/js/src/theme/core/ready.js
+++ b/wp-content/themes/core/js/src/theme/core/ready.js
@@ -79,11 +79,13 @@ const init = () => {
 	components();
 	single();
 
-	// @EXAMPLE_REACT_APP
+	// @EXAMPLE_REACT_APP (Make sure to include the wrapping if block for ALL react apps
 
+	// #if INCLUDEREACT
 	// if ( el.exampleAppRoot && ! HMR_DEV ) {
 	// 	import( 'Example' /* webpackChunkName:"example" */ );
 	// }
+	// #endif
 
 	console.info( 'Square One FE: Initialized all javascript that targeted document ready.' );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6008,6 +6008,13 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
   integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
 
+ifdef-loader@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/ifdef-loader/-/ifdef-loader-2.1.4.tgz#1f0c22f7e92cf216132511b148ca1c3a31d77635"
+  integrity sha512-jwlI3q7PbOU5NlN6pB8atrpx4Yg8gdVNKQIOymlbuHblbShivEZUjsC3Oxwmf9bRApL5NckIiCdB0TGikuHbGQ==
+  dependencies:
+    loader-utils "^1.1.0"
+
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"


### PR DESCRIPTION
With our hybridized build system that allows for injection of react apps as chunks into our main bundles, I ran into one tweak that optimizes build so we arent wasting time.

When you are wanting to work on a react app, you set HMR_DEV true in your local config and fire up the npm task for the react app you want to be working on. The main js bundle then compiles WITHOUT the chunk loading for react apps, as you have a webpack dev server loading an HMR enabled version of your app and this would cause your app to be loading twice, one stale.

Now a problem, when you want to be devving on your main js bundles, admin or theme, your shared react apps are going to be compiled as chunks on every watch reload, a painful experience. So, our dev task, when instantiated by watch, needs to know to exclude the react apps. To accomplish this I brought in ifdef-loader for webpack, and in watch i override the dev configs with the const  INCLUDEREACT as false. I then wrap chunk calls for react app in an ifdef block comment. This causes the react app chunks to be ignored during main bundle runs and brings us back to fast reloads for them.