### PR TITLE
Bugfix: NPM script path to docker logging scripts.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2020.01
 * Add: Added example eslint and phpcs github workflows
+* Fixed: Typo in docker logs naming for NPM scripts. 
 
 ## 2019.12
 * Updated: Node & NPM to latest LTS versions and all FE build tooling to latest (compatible) package versions. Related misc FE build tooling tweaks to accommodate new package versions.

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "codecept:test": "dev/docker/exec.sh /application/www/dev/docker/codecept.sh run",
     "docker:start": "./dev/docker/start.sh",
     "docker:stop": "./dev/docker/stop.sh",
-    "docker:log": "./dev/docker/log.sh",
+    "docker:log": "./dev/docker/logs.sh",
     "docker:wp": "./dev/docker/wp.sh",
     "docker:wpx": "./dev/docker/exec.sh /application/www/dev/docker/wpx.sh",
     "docker:global:start": "./dev/docker/global/start.sh",
     "docker:global:stop": "./dev/docker/global/stop.sh",
-    "docker:global:log": "./dev/docker/global/log.sh",
+    "docker:global:log": "./dev/docker/global/logs.sh",
     "docker:global:cert": "./dev/docker/global/cert.sh"
   },
   "dependencies": {


### PR DESCRIPTION
The path to the docker log.sh scripts (both project & global) were incorrect. This just fixes them.