### PR TITLE
SQ1 + LoadBalancer != real user ip address

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -70,6 +70,16 @@ if ( $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ) {
 	$_SERVER['SERVER_PORT'] = 443;
 }
 
+// ==============================================================
+// If a Load Balancer or Proxy is used, X-Forwarded-For HTTP Header to get the users real IP address
+// ==============================================================
+
+if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+	$http_x_headers = explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] );
+
+	$_SERVER['REMOTE_ADDR'] = $http_x_headers[0];
+}
+
 $config_defaults = [
 
 	// Paths


### PR DESCRIPTION
We recently noticed Glomar's IP detection was not working. It was returning the Load Balancer or Proxy's IP address instead of the original users IP. While we could account for this in the Glomar itself, other plugins or code may not. This fix updates the REMOTE_ADDR server header value if we detect a HTTP_X_FORWARDED_FOR server header exists, which is what the LB and or Proxy is providing from the original users.

I assume this is safe as it's the recommended approach I've found. We could instead simply patch Glomar, but this is a silent issue and will likely happen again if we don't fix it at a higher level.

Debate welcome.