### PR TITLE
Post Type Provider Docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2020.03
 * Fixed: Broken composer.lock file preventing Gravity Forms installation
+* Updated: Docs for Post Type Providers to be consistant with the the existing providers.
 
 ## 2020.02
 * Updated: s3-uploads plugin to 2.2.1

--- a/docs/backend/post-types.md
+++ b/docs/backend/post-types.md
@@ -80,8 +80,12 @@ class Sample_Post_Type_Service_Provider extends Post_Type_Service_Provider {
 The final step in making your post type available is registering it's container in core/src/Core.php
 
 ```php
+use Tribe\Project\Service_Providers\Post_Types\Sample_Post_Type_Service_Provider;
+
+...
+
 private function load_post_type_providers() {
-	$this->container->register( new Sample_Post_Type_Service_Provider() );
+	$this->providers['post_type.sample'] = new Sample_Post_Type_Service_Provider();
 }
 ```
 


### PR DESCRIPTION
Updates post_type example documentation to be consistent with the existing providers.
