### PR TITLE
Allow us to set `opcache.validate_timestamps=0` in php.ini

### DIFF
--- a/wp-content/plugins/core/src/Twig/Twig_Definer.php
+++ b/wp-content/plugins/core/src/Twig/Twig_Definer.php
@@ -6,6 +6,7 @@ namespace Tribe\Project\Twig;
 use DI;
 use Psr\Container\ContainerInterface;
 use Tribe\Libs\Container\Definer_Interface;
+use Twig\Cache\FilesystemCache;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface;
@@ -15,7 +16,7 @@ class Twig_Definer implements Definer_Interface {
 
 	public function define(): array {
 		return [
-			Twig_Cache::class => DI\autowire()->constructor( defined( 'TWIG_CACHE_DIR' ) && TWIG_CACHE_DIR ? TWIG_CACHE_DIR : WP_CONTENT_DIR . '/cache/twig/' ),
+			Twig_Cache::class => DI\autowire()->constructor( defined( 'TWIG_CACHE_DIR' ) && TWIG_CACHE_DIR ? TWIG_CACHE_DIR : WP_CONTENT_DIR . '/cache/twig/', FilesystemCache::FORCE_BYTECODE_INVALIDATION ),
 
 			self::OPTIONS => function ( ContainerInterface $container ) {
 				return apply_filters( 'tribe/project/twig/options', [


### PR DESCRIPTION
Just did this for LL in https://github.com/moderntribe/little-league/pull/428

I think it should be the standard config in the upcoming Template refactor. 