### PR TITLE
Updates certificate expiration days to match 825 day requirement.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2020.04
+* Updated: Certificate creation default date to meet new requirements from [Ballot 193](https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/).
+
 ## 2020.03
 * Added: PHP rules for .editorconfig, including config for many PhpStorm rules
 * Fixed: Broken composer.lock file preventing Gravity Forms installation

--- a/dev/docker/global/cert.sh
+++ b/dev/docker/global/cert.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 1 ]; then
-  echo 1>&2 "Usage: $0 domain.name"
+  echo 1>&2 "Usage: $0 domain.name [days to expiration default=825]"
   exit 2
 fi
 
 DOMAIN=$1
+DAYS=${2:-825}
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 
 cd "$SCRIPTDIR";
@@ -13,7 +14,7 @@ cd "$SCRIPTDIR";
 if [ ! -f "${SCRIPTDIR}/certs/tribeCA.key" ]; then
 	echo "Generating certificate authority"
 
-	openssl req -x509 -new -nodes -sha256 -newkey rsa:4096 -days 3650 \
+	openssl req -x509 -new -nodes -sha256 -newkey rsa:4096 -days ${DAYS} \
 		-keyout "${SCRIPTDIR}/certs/tribeCA.key" \
 		-out "${SCRIPTDIR}/certs/tribeCA.pem" \
 		-subj "/C=US/ST=California/L=Santa Cruz/O=Modern Tribe/OU=Dev/CN=tri.be";
@@ -25,7 +26,7 @@ fi;
 
 echo "Generating SSL certificate for $DOMAIN";
 
-openssl req -new -nodes -sha256 -newkey rsa:4096 -days 3650 \
+openssl req -new -nodes -sha256 -newkey rsa:4096 -days ${DAYS} \
 	-keyout "${SCRIPTDIR}/certs/${DOMAIN}.key" \
 	-out "${SCRIPTDIR}/certs/${DOMAIN}.csr" \
 	-subj "/C=US/ST=California/L=Santa Cruz/O=Modern Tribe/OU=Dev/CN=${DOMAIN}";
@@ -40,7 +41,7 @@ cat > "${SCRIPTDIR}/certs/${DOMAIN}.ext" <<-EOF
 	DNS.2 = *.${DOMAIN}
 EOF
 
-openssl x509 -req -days 3650 -sha256 \
+openssl x509 -req -days ${DAYS} -sha256 \
 	-in "${SCRIPTDIR}/certs/${DOMAIN}.csr" \
 	-CA "${SCRIPTDIR}/certs/tribeCA.pem" \
 	-CAkey "${SCRIPTDIR}/certs/tribeCA.key" \


### PR DESCRIPTION
There is a [requirement](https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/) that has recently gone into effect that certificates can only be created for a maximum of 825 days.
 
The updates set a default number of days to 825 which can be overridden by adding the number of days you would like after the domain option.  This allows you to continue to set the certs to 10 years if you are running on a system that still excepts the larger certificate expiration time. 

## Examples
```sh
./cert.sh domain.tribe 365
```
Overrides the default expiration from 825 days to 365 from today.

```sh
./cert.sh domain.tribe
```
domain.tribe's certificate will expire 825 days from today. 