### PR TITLE
Fixes Alpine nslookup failure when using latest build

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2020.04
+* Fixed: Uses a set version for Alpine in order to have a constant call to nslookup for docker.for.mac.localhost. 
+
 ## 2020.03
 * Added: PHP rules for .editorconfig, including config for many PhpStorm rules
 * Fixed: Broken composer.lock file preventing Gravity Forms installation

--- a/dev/docker/global/start.sh
+++ b/dev/docker/global/start.sh
@@ -25,7 +25,7 @@ fi;
 
 # Newer versions of Docker change the Host IP address. Replace in place on start
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    HOSTIP=`docker run --rm -it alpine nslookup docker.for.mac.localhost | grep "Address 1" | awk  '{ print $3 }' | tail -1`
+    HOSTIP=`docker run --rm -it alpine:3.10 nslookup docker.for.mac.localhost | grep "Address 1" | awk  '{ print $3 }' | tail -1`
     perl -pi -e "s/HOSTIP=.*?$/HOSTIP=${HOSTIP}/" "$SCRIPTDIR/.env"
 fi;
 


### PR DESCRIPTION
The return from the latest version of Alpine was returning inconsistent results  when calling nslookup.  This was keeping host.tribe from being available to the container and keeping xDebug from being able to find the host computer.

This change forces the use of alpine:3.10 in order to provide consistant results  when querying docker.for.mac.locahost.