### PR TITLE
Block editor styles

### DIFF
--- a/wp-content/plugins/core/src/Theme/Resources/Editor_Styles.php
+++ b/wp-content/plugins/core/src/Theme/Resources/Editor_Styles.php
@@ -25,7 +25,7 @@ class Editor_Styles {
 	 *
 	 * @filter tiny_mce_before_init
 	 */
-	public function visual_editor_body_class( $settings ) {
+	public function mce_editor_body_class( $settings ) {
 
 		$settings['body_class'] = ( $settings['body_class'] ?? '' ) . ' t-content';
 
@@ -45,7 +45,7 @@ class Editor_Styles {
 	 * @return array
 	 * @filter editor_stylesheets
 	 */
-	public function visual_editor_styles( $styles ) {
+	public function mce_editor_styles( $styles ) {
 		$theme_uri = get_theme_file_uri( $this->theme_stylesheet_path() );
 		$styles    = array_diff( $styles, [ $theme_uri ] );
 		$styles[]  = get_theme_file_uri( $this->mce_stylesheet_path() );

--- a/wp-content/plugins/core/src/Theme/Resources/Editor_Styles.php
+++ b/wp-content/plugins/core/src/Theme/Resources/Editor_Styles.php
@@ -6,24 +6,23 @@ namespace Tribe\Project\Theme\Resources;
 
 class Editor_Styles {
 	/**
-	 * Visual Editor Styles
-	 * @action after_setup_theme
+	 * Register styles with the block editor.
+	 *
+	 * Uses the relative path, because the block editor will actually grab
+	 * the file from the theme directory and apply some changes to it.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/developers/themes/theme-support/#editor-styles
+	 *
+	 * @action admin_init
 	 */
-	public function visual_editor_styles() {
-
-		$css_dir    = trailingslashit( get_stylesheet_directory_uri() ) . 'assets/css/dist/admin/';
-		$editor_css = 'editor-style.css';
-
-		// Production
-		if ( ! defined( 'SCRIPT_DEBUG' ) || SCRIPT_DEBUG === false ) {
-			$editor_css = 'editor-style.min.css';
-		}
-
-		add_editor_style( $css_dir . $editor_css );
-
+	public function block_editor_styles() {
+		add_editor_style( $this->theme_stylesheet_path() );
+		add_theme_support( 'editor-styles' );
 	}
+
 	/**
-	 * Visual Editor Body Class
+	 * Add a body class to the visual editor
+	 *
 	 * @filter tiny_mce_before_init
 	 */
 	public function visual_editor_body_class( $settings ) {
@@ -32,5 +31,46 @@ class Editor_Styles {
 
 		return $settings;
 
+	}
+
+	/**
+	 * Filter the styles sent to the MCE editor.
+	 *
+	 * We don't want to apply the full block editor styles, so
+	 * this will remove those and replace them with the CSS
+	 * specific to the MCE editor
+	 *
+	 * @param array $styles
+	 *
+	 * @return array
+	 * @filter editor_stylesheets
+	 */
+	public function visual_editor_styles( $styles ) {
+		$theme_uri = get_theme_file_uri( $this->theme_stylesheet_path() );
+		$styles    = array_diff( $styles, [ $theme_uri ] );
+		$styles[]  = get_theme_file_uri( $this->mce_stylesheet_path() );
+
+		return $styles;
+	}
+
+	/**
+	 * @return string The relative path to the theme stylesheet
+	 */
+	private function theme_stylesheet_path(): string {
+		return 'assets/css/dist/theme/master' . $this->file_suffix();
+	}
+
+	/**
+	 * @return string The relative path to the MCE stylesheet
+	 */
+	private function mce_stylesheet_path(): string {
+		return 'assets/css/dist/admin/editor-style' . $this->file_suffix();
+	}
+
+	/**
+	 * @return string The file suffix to use for the stylesheet, based on the SCRIPT_DEBUG configuration
+	 */
+	private function file_suffix(): string {
+		return ! defined( 'SCRIPT_DEBUG' ) || SCRIPT_DEBUG === false ? '.min.css' : '.css';
 	}
 }

--- a/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
+++ b/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
@@ -181,11 +181,14 @@ class Theme_Subscriber implements Subscriber_Interface {
 	}
 
 	private function editor_styles( ContainerInterface $container ) {
-		add_action( 'after_setup_theme', function () use ( $container ) {
-			$container->get( Editor_Styles::class )->visual_editor_styles();
+		add_action( 'admin_init', function () use ( $container ) {
+			$container->get( Editor_Styles::class )->block_editor_styles();
 		}, 10, 0 );
 		add_filter( 'tiny_mce_before_init', function ( $settings ) use ( $container ) {
 			return $container->get( Editor_Styles::class )->visual_editor_body_class( $settings );
+		}, 10, 1 );
+		add_filter( 'editor_stylesheets', function( $styles ) use ( $container ) {
+			return $container->get( Editor_Styles::class )->visual_editor_styles( $styles );
 		}, 10, 1 );
 	}
 

--- a/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
+++ b/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
@@ -185,10 +185,10 @@ class Theme_Subscriber implements Subscriber_Interface {
 			$container->get( Editor_Styles::class )->block_editor_styles();
 		}, 10, 0 );
 		add_filter( 'tiny_mce_before_init', function ( $settings ) use ( $container ) {
-			return $container->get( Editor_Styles::class )->visual_editor_body_class( $settings );
+			return $container->get( Editor_Styles::class )->mce_editor_body_class( $settings );
 		}, 10, 1 );
 		add_filter( 'editor_stylesheets', function( $styles ) use ( $container ) {
-			return $container->get( Editor_Styles::class )->visual_editor_styles( $styles );
+			return $container->get( Editor_Styles::class )->mce_editor_styles( $styles );
 		}, 10, 1 );
 	}
 


### PR DESCRIPTION
Enqueues the full front-end stylesheet for the block editor, keeping the existing `editor-style.css` for the classic editor.