### PR TITLE
Remove Relative positioning from the .g-col class

### DIFF
--- a/wp-content/themes/core/pcss/base/grid/_columns.pcss
+++ b/wp-content/themes/core/pcss/base/grid/_columns.pcss
@@ -6,7 +6,6 @@
 
 .g-col {
 	min-width: 0;
-	position: relative;
 	width: 100%;
 }
 


### PR DESCRIPTION
This property blocks flexibility when trying to position elements relative to a higher hierarchy element. Checking on dependency on that removed `position: relative`, I couldn't find any.