### PR TITLE
add tagline field for accordion

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -993,12 +993,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:moderntribe/gutenpanels.git",
-                "reference": "383dfbb83bafe1b61d81d2c3df59f4732d46e44b"
+                "reference": "fbb7fdc918ddd85992203fc9cc2d501e0c61f6e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moderntribe/gutenpanels/zipball/383dfbb83bafe1b61d81d2c3df59f4732d46e44b",
-                "reference": "383dfbb83bafe1b61d81d2c3df59f4732d46e44b",
+                "url": "https://api.github.com/repos/moderntribe/gutenpanels/zipball/fbb7fdc918ddd85992203fc9cc2d501e0c61f6e5",
+                "reference": "fbb7fdc918ddd85992203fc9cc2d501e0c61f6e5",
                 "shasum": ""
             },
             "require": {
@@ -1032,7 +1032,7 @@
                 }
             ],
             "description": "The Modern Tribe Panel Builder plugin, now with more Gutenberg!",
-            "time": "2020-04-17T14:39:28+00:00"
+            "time": "2020-04-20T14:28:38+00:00"
         },
         {
             "name": "moderntribe/panel-builder",

--- a/wp-content/plugins/core/src/Blocks/Types/Accordion.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Accordion.php
@@ -13,6 +13,7 @@ class Accordion extends Block_Type_Config {
 	public const NAME = 'tribe/accordion';
 
 	public const LAYOUT      = 'layout';
+	public const TAGLINE     = 'tagline';
 	public const TITLE       = 'title';
 	public const DESCRIPTION = 'description';
 	public const ACCORDION   = 'accordion';
@@ -25,8 +26,8 @@ class Accordion extends Block_Type_Config {
 			->set_label( 'Accordion' )
 			->set_dashicon( 'menu-alt3' )
 			->add_layout_property( 'grid-template-areas', "'content' 'accordion'" )
-			->add_conditional_layout_property( 'grid-template-areas', "'content accordion accordion'", self::LAYOUT, '==', self::LAYOUT_INLINE )
-			->add_sidebar_section( $this->layout_sidebar() )
+			//->add_conditional_layout_property( 'grid-template-areas', "'content accordion accordion'", self::LAYOUT, '==', self::LAYOUT_INLINE )
+			//->add_sidebar_section( $this->layout_sidebar() )
 			->add_content_section( $this->content_area() )
 			->add_content_section( $this->accordions_area() )
 			->build();
@@ -49,12 +50,20 @@ class Accordion extends Block_Type_Config {
 		return $this->factory->content()->section()
 			->set_layout_property( 'grid-area', 'content' )
 			->add_field(
+				$this->factory->content()->field()->text( self::TAGLINE )
+					->set_label( __( 'Tagline', 'tribe' ) )
+					->set_placeholder( __( 'Enter a short tagline', 'tribe' ) )
+					->build()
+			)
+			->add_field(
 				$this->factory->content()->field()->text( self::TITLE )
+					->set_label( __( 'Title', 'tribe' ) )
 					->add_class( 'h2' )
 					->build()
 			)
 			->add_field(
 				$this->factory->content()->field()->richtext( self::DESCRIPTION )
+					->set_label( __( 'Description', 'tribe' ) )
 					->build()
 			)
 			->build();


### PR DESCRIPTION
Per the scope in https://moderntribe.atlassian.net/browse/SQONE-358, Accordion blocks should have a tagline, but should not have layout options.