### PR TITLE
Add SQ1_UID docker argument and environment variable

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -33,6 +33,9 @@ x-chrome: &chrome
 
 x-php: &php
   image: moderntribe/squareone-php:74-1.1.0
+  build:
+    args:
+      SQ1_UID: "${SQ1_UID}"
   working_dir: /application
   volumes:
     - ../..:/application/www:cached


### PR DESCRIPTION
## What does this do/fix?

This should hopefully allow SquareOne Global Docker to set the host's ID as the `SQ1_UID` environment variable and pass it to docker-compose.yml to pass to the Dockerfile as an argument (untested).

## QA

https://github.com/moderntribe/squareone-docker-images/pull/1#discussion_r437787226

## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because...it's a config file :)
- [ ] No, I need help figuring out how to write the tests.

