### PR TITLE
Editor Theme Scripts

### DIFF
--- a/wp-content/themes/core/assets/js/src/admin/core/plugins.js
+++ b/wp-content/themes/core/assets/js/src/admin/core/plugins.js
@@ -1,4 +1,3 @@
-// @flow
 /**
  * @module
  * @exports plugins

--- a/wp-content/themes/core/assets/js/src/admin/core/ready.js
+++ b/wp-content/themes/core/assets/js/src/admin/core/ready.js
@@ -47,7 +47,7 @@ const init = () => {
 
 	editor();
 
-	console.info( 'Square One BE: Initialized all javascript that targeted document ready.' );
+	console.info( 'SquareOne Admin: Initialized all javascript that targeted document ready.' );
 };
 
 /**

--- a/wp-content/themes/core/assets/js/src/admin/editor/index.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/index.js
@@ -1,5 +1,6 @@
 import hooks from './hooks';
 import types from './types';
+import * as tools from 'utils/tools';
 
 /**
  * @function init
@@ -9,6 +10,12 @@ import types from './types';
 const init = () => {
 	hooks();
 	types();
+
+	if ( tools.getNodes( '#editor.block-editor__container', false, document, true )[ 0 ] ) {
+		import( './preview' /* webpackChunkName:"editor-preview" */ ).then( ( module ) => {
+			module.default();
+		} );
+	}
 };
 
 export default init;

--- a/wp-content/themes/core/assets/js/src/admin/editor/preview.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/preview.js
@@ -1,0 +1,16 @@
+import 'lazysizes';
+import 'lazysizes/plugins/object-fit/ls.object-fit';
+import 'lazysizes/plugins/parent-fit/ls.parent-fit';
+import 'lazysizes/plugins/respimg/ls.respimg';
+import 'lazysizes/plugins/bgset/ls.bgset';
+
+/**
+ * @function init
+ * @description Initialize module
+ */
+
+const init = () => {
+	console.info( 'SquareOne Admin: Initialized scripts needed for the editor preview.' );
+};
+
+export default init;

--- a/wp-content/themes/core/assets/js/src/admin/editor/types.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/types.js
@@ -17,7 +17,7 @@ const removeBlackListedBlocks = () => {
 
 	blocksToUnregister.forEach( type => unregisterBlockType( type ) );
 
-	console.info( 'SquareOne BE: Unregistered these blocks from Gutenberg: ', blocksToUnregister );
+	console.info( 'SquareOne Admin: Unregistered these blocks from Gutenberg: ', blocksToUnregister );
 };
 
 /**

--- a/wp-content/themes/core/assets/js/src/theme/core/components.js
+++ b/wp-content/themes/core/assets/js/src/theme/core/components.js
@@ -19,7 +19,7 @@ const init = () => {
 	tabs();
 	video();
 
-	console.info( 'SquareOne FE: Initialized all components.' );
+	console.info( 'SquareOne Theme: Initialized all components.' );
 };
 
 export default init;

--- a/wp-content/themes/core/assets/js/src/theme/core/integrations.js
+++ b/wp-content/themes/core/assets/js/src/theme/core/integrations.js
@@ -9,7 +9,7 @@ import gravityForms from 'integrations/gravity-forms';
 const init = () => {
 	gravityForms();
 
-	console.info( 'SquareOne FE: Initialized all integrations.' );
+	console.info( 'SquareOne Theme: Initialized all integrations.' );
 };
 
 export default init;

--- a/wp-content/themes/core/assets/js/src/theme/core/ready.js
+++ b/wp-content/themes/core/assets/js/src/theme/core/ready.js
@@ -77,7 +77,7 @@ const init = () => {
 	// 	} );
 	// }
 
-	console.info( 'Square One FE: Initialized all javascript that targeted document ready.' );
+	console.info( 'SquareOne Theme: Initialized all javascript that targeted document ready.' );
 };
 
 /**

--- a/wp-content/themes/core/components/accordion/js/accordion.js
+++ b/wp-content/themes/core/components/accordion/js/accordion.js
@@ -152,7 +152,7 @@ const init = () => {
 	setOffset();
 	bindEvents();
 
-	console.info( 'Square One FE: Initialized accordion component scripts.' );
+	console.info( 'SquareOne Theme: Initialized accordion component scripts.' );
 };
 
 export default init;

--- a/wp-content/themes/core/components/comments/js/comments.js
+++ b/wp-content/themes/core/components/comments/js/comments.js
@@ -57,7 +57,7 @@ const init = () => {
 
 	bindEvents();
 
-	console.info( 'Square One FE: Initialized comment form script.' );
+	console.info( 'SquareOne Theme: Initialized comment form script.' );
 };
 
 export default init;

--- a/wp-content/themes/core/components/share/js/share.js
+++ b/wp-content/themes/core/components/share/js/share.js
@@ -54,7 +54,7 @@ const socialShare = () => {
 
 	bindEvents();
 
-	console.info( 'Square One FE: Initialized global social content sharing scripts.' );
+	console.info( 'SquareOne Theme: Initialized global social content sharing scripts.' );
 };
 
 export default socialShare;

--- a/wp-content/themes/core/components/slider/js/slider.js
+++ b/wp-content/themes/core/components/slider/js/slider.js
@@ -173,7 +173,7 @@ const init = () => {
 	initSliders();
 	bindEvents();
 
-	console.info( 'Square One FE: Initialized slider component scripts.' );
+	console.info( 'SquareOne Theme: Initialized slider component scripts.' );
 };
 
 export default init;

--- a/wp-content/themes/core/components/tabs/js/tabs.js
+++ b/wp-content/themes/core/components/tabs/js/tabs.js
@@ -110,7 +110,7 @@ const init = () => {
 
 	bindEvents();
 
-	console.info( 'Square One FE: Initialized tabs component scripts.' );
+	console.info( 'SquareOne Theme: Initialized tabs component scripts.' );
 };
 
 export default init;

--- a/wp-content/themes/core/components/video/js/video.js
+++ b/wp-content/themes/core/components/video/js/video.js
@@ -162,7 +162,7 @@ const videoEmbeds = () => {
 	bindEvents();
 	setupOembeds();
 
-	console.info( 'Square One FE: Initialized video embeds scripts.' );
+	console.info( 'SquareOne Theme: Initialized video embeds scripts.' );
 };
 
 export default videoEmbeds;

--- a/wp-content/themes/core/integrations/gravity-forms/js/gravity-forms.js
+++ b/wp-content/themes/core/integrations/gravity-forms/js/gravity-forms.js
@@ -108,7 +108,7 @@ const gravityForms = () => {
 
 	bindEvents();
 
-	console.info( 'Square One FE: Initialized global form scripts.' );
+	console.info( 'SquareOne Theme: Initialized global form scripts.' );
 };
 
 export default gravityForms;


### PR DESCRIPTION
We need to run some theme js and plugins in the gutenberg editor. This sets up a chunk to do that and runs our lazyloading scripts. Since we are using mutation observers in lazysizes, coming back from edit ui or any deferred loading of lazy images works as expected.

Next up we'll probably start bring in the theme side  component js as needed, eg the slider scripts, but have to setup an event system for that to work with the above concern.