### PR TITLE
disable all gravityform styles - SQONE-308

### DIFF
--- a/wp-content/plugins/core/src/Integrations/Gravity_Forms/Form_Styles.php
+++ b/wp-content/plugins/core/src/Integrations/Gravity_Forms/Form_Styles.php
@@ -22,6 +22,14 @@ class Form_Styles {
 	}
 
 	/**
+	 * @return string
+	 * @filter pre_option_rg_gforms_disable_css
+	 */
+	public function disable_gravity_forms_css(): string {
+		return '1';
+	}
+
+	/**
 	 * Dequeue styles for formsmain on Gravity Forms.
 	 * This prevents GF styles from interferring with our sink form styles.
 	 *

--- a/wp-content/plugins/core/src/Integrations/Gravity_Forms/Gravity_Forms_Subscriber.php
+++ b/wp-content/plugins/core/src/Integrations/Gravity_Forms/Gravity_Forms_Subscriber.php
@@ -28,5 +28,9 @@ class Gravity_Forms_Subscriber extends Abstract_Subscriber {
 		add_filter( 'gform_pre_render', function ( $form ) {
 			return $this->container->get( Form_Styles::class )->deactivate_gf_animations( $form );
 		} );
+
+		add_filter( 'pre_option_rg_gforms_disable_css', function () {
+			return $this->container->get( Form_Styles::class )->disable_gravity_forms_css();
+		}, 10, 0 );
 	}
 }


### PR DESCRIPTION
## What does this do/fix?

Disables all gravity form styles by filtering the option to enable/disable them. This is to address form styling issues in the block editor. https://moderntribe.atlassian.net/browse/SQONE-308?focusedCommentId=75871

This has the consequence of disabling _all_ of the gform style, and I'm not sure if that's really what we want. We had been dequeuing just `gforms_formsmain_css`. This filter will also dequeue:

- `gforms_reset_css`
- `gforms_datepicker_css`
- `gforms_ready_class_css`
- `gforms_browsers_css`

It looks OK to me, but I don't have the knowledge to know if this is correct.

@jamiepaul, can you let me know if this works?
