### PR TITLE
Save markup in output buffer and actually return it once cached

### DIFF
--- a/wp-content/plugins/core/functions/templates.php
+++ b/wp-content/plugins/core/functions/templates.php
@@ -14,4 +14,3 @@ if ( ! function_exists( 'tribe_template_part' ) ) {
 		return ob_get_clean();
 	}
 }
-

--- a/wp-content/plugins/core/functions/templates.php
+++ b/wp-content/plugins/core/functions/templates.php
@@ -1,1 +1,17 @@
 <?php
+if ( ! function_exists( 'tribe_template_part' ) ) {
+	/**
+	 * @param string $slug
+	 * @param string $name
+	 * @param array  $args
+	 *
+	 * @return false|string
+	 */
+	function tribe_template_part( $slug, $name = null, $args = [] ) {
+		ob_start();
+		get_template_part( $slug, $name, $args );
+
+		return ob_get_clean();
+	}
+}
+

--- a/wp-content/plugins/core/src/Theme/Media/Oembed_Filter.php
+++ b/wp-content/plugins/core/src/Theme/Media/Oembed_Filter.php
@@ -61,9 +61,7 @@ class Oembed_Filter {
 			'trigger_label'    => $data->title,
 			'trigger_position' => Controller::TRIGGER_POSITION_BOTTOM, // Options: bottom, center
 		];
-		ob_start();
-		get_template_part( 'components/video/video', null, $options );
-		$frontend_html = ob_get_clean();
+		$frontend_html = tribe_template_part( 'components/video/video', null, $options );
 		$this->cache_frontend_html( $frontend_html, $url );
 
 		return $frontend_html;

--- a/wp-content/plugins/core/src/Theme/Media/Oembed_Filter.php
+++ b/wp-content/plugins/core/src/Theme/Media/Oembed_Filter.php
@@ -61,12 +61,12 @@ class Oembed_Filter {
 			'trigger_label'    => $data->title,
 			'trigger_position' => Controller::TRIGGER_POSITION_BOTTOM, // Options: bottom, center
 		];
-
-		$frontend_html = get_template_part( 'components/video/video', null, $options );
-
+		ob_start();
+		get_template_part( 'components/video/video', null, $options );
+		$frontend_html = ob_get_clean();
 		$this->cache_frontend_html( $frontend_html, $url );
 
-		return $html;
+		return $frontend_html;
 	}
 
 	private function get_layout_container_attrs( $provider_name, $embed_id, $title ): array {


### PR DESCRIPTION
## What does this do/fix?

Fixes the Oembed filter

@jbrinley question on this. Ryan and I were talking and we can see instances where a "dumb" component may need to be generated in a higher Controller and using `get_template_part` without the output buffer won't work. Do you see any value in having a `tribe_get_template_part` wrapper with an optional `$echo` arg in case this becomes a thing? Obviously we don't want a ton of output sitting in memory but interested on your thoughts here. 
