### PR TITLE
Feeture/finished component class usage

### DIFF
--- a/wp-content/plugins/core/src/Theme/Media/Oembed_Filter.php
+++ b/wp-content/plugins/core/src/Theme/Media/Oembed_Filter.php
@@ -39,7 +39,7 @@ class Oembed_Filter {
 			return $html;
 		}
 
-		$classes = [ 'c-video', 'c-video--lazy' ];
+		$classes = [ 'c-video--lazy' ];
 
 		if ( $data->provider_name === self::PROVIDER_YOUTUBE ) {
 			$embed_id    = $this->get_youtube_embed_id( $url );

--- a/wp-content/themes/core/components/breadcrumbs/Controller.php
+++ b/wp-content/themes/core/components/breadcrumbs/Controller.php
@@ -47,13 +47,13 @@ class Controller extends Abstract_Controller {
 
 	public function __construct( array $args = [] ) {
 		$this->breadcrumbs     = (array) ( $args['breadcrumbs'] ?? [] );
-		$this->wrapper_classes = array_merge( [ 'c-breadcrumbs' ], (array) $args['wrapper_classes'] ?? [] );
+		$this->wrapper_classes = array_merge( [ 'c-breadcrumbs' ], (array) ( $args['wrapper_classes'] ?? [] ) );
 		$this->wrapper_attrs   = (array) ( $args['wrapper_attrs'] ?? [] );
-		$this->main_classes    = array_merge( [ 'c-breadcrumbs__list' ], (array) $args['main_classes'] ?? [] );
+		$this->main_classes    = array_merge( [ 'c-breadcrumbs__list' ], (array) ( $args['main_classes'] ?? [] ) );
 		$this->main_attrs      = (array) ( $args['main_attrs'] ?? [] );
-		$this->item_classes    = array_merge( [ 'c-breadcrumbs__item' ], (array) $args['item_classes'] ?? [] );
+		$this->item_classes    = array_merge( [ 'c-breadcrumbs__item' ], (array) ( $args['item_classes'] ?? [] ) );
 		$this->item_attrs      = (array) ( $args['item_attrs'] ?? [] );
-		$this->link_classes    = array_merge( [ 'c-breadcrumbs__anchor' ], (array) $args['link_classes'] ?? [] );
+		$this->link_classes    = array_merge( [ 'c-breadcrumbs__anchor' ], (array) ( $args['link_classes'] ?? [] ) );
 		$this->link_attrs      = (array) ( $args['link_attrs'] ?? [] );
 	}
 

--- a/wp-content/themes/core/components/breadcrumbs/Controller.php
+++ b/wp-content/themes/core/components/breadcrumbs/Controller.php
@@ -47,13 +47,13 @@ class Controller extends Abstract_Controller {
 
 	public function __construct( array $args = [] ) {
 		$this->breadcrumbs     = (array) ( $args['breadcrumbs'] ?? [] );
-		$this->wrapper_classes = (array) ( $args['wrapper_classes'] ?? [] );
+		$this->wrapper_classes = array_merge( [ 'c-breadcrumbs' ], (array) $args['wrapper_classes'] ?? [] );
 		$this->wrapper_attrs   = (array) ( $args['wrapper_attrs'] ?? [] );
-		$this->main_classes    = (array) ( $args['main_classes'] ?? [] );
+		$this->main_classes    = array_merge( [ 'c-breadcrumbs__list' ], (array) $args['main_classes'] ?? [] );
 		$this->main_attrs      = (array) ( $args['main_attrs'] ?? [] );
-		$this->item_classes    = (array) ( $args['item_classes'] ?? [] );
+		$this->item_classes    = array_merge( [ 'c-breadcrumbs__item' ], (array) $args['item_classes'] ?? [] );
 		$this->item_attrs      = (array) ( $args['item_attrs'] ?? [] );
-		$this->link_classes    = (array) ( $args['link_classes'] ?? [] );
+		$this->link_classes    = array_merge( [ 'c-breadcrumbs__anchor' ], (array) $args['link_classes'] ?? [] );
 		$this->link_attrs      = (array) ( $args['link_attrs'] ?? [] );
 	}
 

--- a/wp-content/themes/core/components/breadcrumbs/css/breadcrumbs.pcss
+++ b/wp-content/themes/core/components/breadcrumbs/css/breadcrumbs.pcss
@@ -4,24 +4,24 @@
  *
  * ----------------------------------------------------------------------------- */
 
-.c-breadcrumbs__wrapper {
+.c-breadcrumbs {
 
 }
 
-.c-breadcrumbs {
+.c-breadcrumbs__list {
 	display: flex;
 	flex-direction: row;
+}
 
-	.c-breadcrumbs__item {
-		margin-right: 10px;
-		width: auto;
+.c-breadcrumbs__item {
+	margin-right: 10px;
+	width: auto;
 
-		&:last-child {
-			margin-right: 0;
-		}
+	&:last-child {
+		margin-right: 0;
 	}
+}
 
-	.c-breadcrumbs__anchor {
+.c-breadcrumbs__anchor {
 
-	}
 }

--- a/wp-content/themes/core/components/card/Controller.php
+++ b/wp-content/themes/core/components/card/Controller.php
@@ -41,9 +41,9 @@ class Controller extends Abstract_Controller {
 		$this->image                = (array) ( $args['image'] ?? [] );
 		$this->pre_title            = $args['pre_title'] ?? '';
 		$this->post_title           = $args['post_title'] ?? '';
-		$this->card_classes         = array_merge( [ 'c-card' ], (array) $args['card_classes'] ?? [] );
-		$this->card_header_classes  = array_merge( [ 'c-card__header' ], (array) $args['card_header_classes'] ?? [] );
-		$this->card_content_classes = array_merge( [ 'c-card__content' ], (array) $args['card_content_classes'] ?? [] );
+		$this->card_classes         = array_merge( [ 'c-card' ], (array) ( $args['card_classes'] ?? [] ) );
+		$this->card_header_classes  = array_merge( [ 'c-card__header' ], (array) ( $args['card_header_classes'] ?? [] ) );
+		$this->card_content_classes = array_merge( [ 'c-card__content' ], (array) ( $args['card_content_classes'] ?? [] ) );
 		$this->button               = (array) ( $args['button'] ?? [] );
 	}
 }

--- a/wp-content/themes/core/components/card/Controller.php
+++ b/wp-content/themes/core/components/card/Controller.php
@@ -41,9 +41,9 @@ class Controller extends Abstract_Controller {
 		$this->image                = (array) ( $args['image'] ?? [] );
 		$this->pre_title            = $args['pre_title'] ?? '';
 		$this->post_title           = $args['post_title'] ?? '';
-		$this->card_classes         = (array) ( $args['card_classes'] ?? [ 'c-card' ] );
-		$this->card_header_classes  = (array) ( $args['card_header_classes'] ?? [ 'c-card__header' ] );
-		$this->card_content_classes = (array) ( $args['card_content_classes'] ?? [ 'c-card__content' ] );
+		$this->card_classes         = array_merge( [ 'c-card' ], (array) $args['card_classes'] ?? [] );
+		$this->card_header_classes  = array_merge( [ 'c-card__header' ], (array) $args['card_header_classes'] ?? [] );
+		$this->card_content_classes = array_merge( [ 'c-card__content' ], (array) $args['card_content_classes'] ?? [] );
 		$this->button               = (array) ( $args['button'] ?? [] );
 	}
 }

--- a/wp-content/themes/core/components/content/no_results/no_results.php
+++ b/wp-content/themes/core/components/content/no_results/no_results.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 $controller = \Tribe\Project\Templates\Components\content\no_results\Controller::factory();
 ?>
 
-<aside class="no-results">
+<div class="no-results">
 
 	<h3 class="no-results__title">
 		<?php echo esc_html( __( 'No Posts', 'tribe' ) ); ?>
@@ -13,4 +13,4 @@ $controller = \Tribe\Project\Templates\Components\content\no_results\Controller:
 		<?php echo esc_html( __( 'Sorry, but there are currently no posts to see at this time.', 'tribe' ) ); ?>
 	</p>
 
-</aside>
+</div>

--- a/wp-content/themes/core/components/document/head/Controller.php
+++ b/wp-content/themes/core/components/document/head/Controller.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace Tribe\Project\Templates\Components\head;
+namespace Tribe\Project\Templates\Components\document\head;
 
 use Tribe\Project\Templates\Components\Abstract_Controller;
 

--- a/wp-content/themes/core/components/document/head/head.php
+++ b/wp-content/themes/core/components/document/head/head.php
@@ -1,6 +1,6 @@
 <?php
 declare( strict_types=1 );
-$controller = \Tribe\Project\Templates\Components\head\Controller::factory();
+$controller = \Tribe\Project\Templates\Components\document\head\Controller::factory();
 ?>
 <head>
 	<?php // TITLE: Handled by WP ?>

--- a/wp-content/themes/core/components/document/header/header.php
+++ b/wp-content/themes/core/components/document/header/header.php
@@ -4,7 +4,7 @@ $controller = \Tribe\Project\Templates\Components\document\header\Controller::fa
 ?>
 <!DOCTYPE html>
 <html <?php echo $controller->language_attributes(); ?>>
-<?php get_template_part( 'components/head/head' ); ?>
+<?php get_template_part( 'components/document/head/head' ); ?>
 <body class="<?php echo esc_attr( $controller->body_class() ); ?>">
 
 	<?php do_action( 'tribe/body_opening_tag' ) ?>

--- a/wp-content/themes/core/components/follow/follow.php
+++ b/wp-content/themes/core/components/follow/follow.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 $controller = \Tribe\Project\Templates\Components\follow\Controller::factory();
 
 ?>
-<aside class="social-follow">
+<div class="social-follow">
 
 	<ul class="social-follow__list">
 		<?php foreach ( $controller->social_links() as $item ) { ?>
@@ -18,4 +18,4 @@ $controller = \Tribe\Project\Templates\Components\follow\Controller::factory();
 		<?php } ?>
 	</ul>
 
-</aside>
+</div>

--- a/wp-content/themes/core/components/header/subheader/Controller.php
+++ b/wp-content/themes/core/components/header/subheader/Controller.php
@@ -8,8 +8,8 @@ use Tribe\Project\Templates\Components\Abstract_Controller;
 class Controller extends Abstract_Controller {
 
 	public function title(): string {
-		// TODO: hook up/use text component.
-		//  Also, make sure it handles CPTs with dates.
+		// TODO: implement a wrapper/container component
+		// TODO: use the method in head/controller.php?
 		return get_the_title();
 	}
 }

--- a/wp-content/themes/core/components/image/Controller.php
+++ b/wp-content/themes/core/components/image/Controller.php
@@ -82,7 +82,7 @@ class Controller extends Abstract_Controller {
 		// append an html string inside the wrapper. Useful for adding a `<figcaption>` or other markup after the image
 		$this->html = $args['html'] ?? '';
 		// pass classes for image tag. if lazyload is true class "lazyload" is auto added
-		$this->img_classes = array_merge( [ 'c-image__image' ], (array) $args['img_classes'] ?? [] );
+		$this->img_classes = array_merge( [ 'c-image__image' ], (array) ( $args['img_classes'] ?? [] ) );
 		// additional image attributes
 		$this->img_attrs = (array) ( $args['img_attrs'] ?? [] );
 		// pass specific image alternate text. if not included, will default to image title
@@ -90,7 +90,7 @@ class Controller extends Abstract_Controller {
 		// pass a link to wrap the image
 		$this->link_url = $args['link_url'] ?? '';
 		// pass link classes
-		$this->link_classes = array_merge( [ 'c-image__link' ], (array) $args['link_classes'] ?? [] );
+		$this->link_classes = array_merge( [ 'c-image__link' ], (array) ( $args['link_classes'] ?? [] ) );
 		// pass a link target
 		$this->link_target = $args['link_target'] ?? '';
 		// pass a link title
@@ -117,7 +117,7 @@ class Controller extends Abstract_Controller {
 		$this->use_srcset = $args['use_srcset'] ?? true;
 		$this->wrapper_attrs = (array) ( $args['wrapper_attrs'] ?? [] );
 		// pass classes for figure wrapper. If as_bg is set true gets auto class of "lazyload"
-		$this->wrapper_classes = array_merge( [ 'c-image' ], (array) $args['classes'] ?? [] );
+		$this->wrapper_classes = array_merge( [ 'c-image' ], (array) ( $args['classes'] ?? [] ) );
 		// html tag for the wrapper/background image container
 		$this->wrapper_tag = $args['wrapper_tag'] ?? 'figure';
 	}

--- a/wp-content/themes/core/components/image/Controller.php
+++ b/wp-content/themes/core/components/image/Controller.php
@@ -82,7 +82,7 @@ class Controller extends Abstract_Controller {
 		// append an html string inside the wrapper. Useful for adding a `<figcaption>` or other markup after the image
 		$this->html = $args['html'] ?? '';
 		// pass classes for image tag. if lazyload is true class "lazyload" is auto added
-		$this->img_classes = (array) ( $args['img_classes'] ?? [ 'c-image__image' ] );
+		$this->img_classes = array_merge( [ 'c-image__image' ], (array) $args['img_classes'] ?? [] );
 		// additional image attributes
 		$this->img_attrs = (array) ( $args['img_attrs'] ?? [] );
 		// pass specific image alternate text. if not included, will default to image title
@@ -90,7 +90,7 @@ class Controller extends Abstract_Controller {
 		// pass a link to wrap the image
 		$this->link_url = $args['link_url'] ?? '';
 		// pass link classes
-		$this->link_classes = (array) ( $args['link_classes'] ?? [ 'c-image__link' ] );
+		$this->link_classes = array_merge( [ 'c-image__link' ], (array) $args['link_classes'] ?? [] );
 		// pass a link target
 		$this->link_target = $args['link_target'] ?? '';
 		// pass a link title
@@ -117,7 +117,7 @@ class Controller extends Abstract_Controller {
 		$this->use_srcset = $args['use_srcset'] ?? true;
 		$this->wrapper_attrs = (array) ( $args['wrapper_attrs'] ?? [] );
 		// pass classes for figure wrapper. If as_bg is set true gets auto class of "lazyload"
-		$this->wrapper_classes = (array) ( $args['classes'] ?? [ 'c-image' ] );
+		$this->wrapper_classes = array_merge( [ 'c-image' ], (array) $args['classes'] ?? [] );
 		// html tag for the wrapper/background image container
 		$this->wrapper_tag = $args['wrapper_tag'] ?? 'figure';
 	}

--- a/wp-content/themes/core/components/pagination/loop/Controller.php
+++ b/wp-content/themes/core/components/pagination/loop/Controller.php
@@ -40,15 +40,11 @@ class Controller extends Abstract_Controller {
 	private $links;
 
 	public function __construct( array $args = [] ) {
-		$this->wrapper_classes = (array) ( $args['wrapper_classes'] ?? [ 'c-pagination', 'c-pagination--loop' ] );
+		$this->wrapper_classes = array_merge( [ 'c-pagination', 'c-pagination--loop' ], (array) $args['wrapper_classes'] ?? [] );
 		$this->wrapper_attrs   = (array) ( $args['wrapper_attrs'] ?? [ 'aria-labelledby' => 'c-pagination__label-single' ] );
-		$this->list_classes    = (array) ( $args['list_classes'] ?? [
-				'g-row',
-				'g-row--no-gutters',
-				'c-pagination__list',
-			] );
+		$this->list_classes    = array_merge( [ 'c-pagination__list' ], (array) $args['list_classes'] ?? [] );
 		$this->list_attrs      = (array) ( $args['list_attrs'] ?? [] );
-		$this->item_classes    = (array) ( $args['item_classes'] ?? [ 'g-col', 'c-pagination__item' ] );
+		$this->item_classes    = array_merge( [ 'c-pagination__item' ], (array) $args['item_classes'] ?? [] );
 		$this->item_attrs      = (array) ( $args['item_attrs'] ?? [] );
 	}
 

--- a/wp-content/themes/core/components/pagination/loop/Controller.php
+++ b/wp-content/themes/core/components/pagination/loop/Controller.php
@@ -40,11 +40,11 @@ class Controller extends Abstract_Controller {
 	private $links;
 
 	public function __construct( array $args = [] ) {
-		$this->wrapper_classes = array_merge( [ 'c-pagination', 'c-pagination--loop' ], (array) $args['wrapper_classes'] ?? [] );
+		$this->wrapper_classes = array_merge( [ 'c-pagination', 'c-pagination--loop' ], (array) ( $args['wrapper_classes'] ?? [] ) );
 		$this->wrapper_attrs   = (array) ( $args['wrapper_attrs'] ?? [ 'aria-labelledby' => 'c-pagination__label-single' ] );
-		$this->list_classes    = array_merge( [ 'c-pagination__list' ], (array) $args['list_classes'] ?? [] );
+		$this->list_classes    = array_merge( [ 'c-pagination__list' ], (array) ( $args['list_classes'] ?? [] ) );
 		$this->list_attrs      = (array) ( $args['list_attrs'] ?? [] );
-		$this->item_classes    = array_merge( [ 'c-pagination__item' ], (array) $args['item_classes'] ?? [] );
+		$this->item_classes    = array_merge( [ 'c-pagination__item' ], (array) ( $args['item_classes'] ?? [] ) );
 		$this->item_attrs      = (array) ( $args['item_attrs'] ?? [] );
 	}
 

--- a/wp-content/themes/core/components/video/Controller.php
+++ b/wp-content/themes/core/components/video/Controller.php
@@ -32,14 +32,14 @@ class Controller extends Abstract_Controller {
 	public const TRIGGER_POSITION_BOTTOM = 'bottom';
 
 	public function __construct( array $args = [] ) {
-		$this->classes          = (array) ( $args['classes'] ?? [ 'c-video', sprintf( 'c-video--trigger-%s', $this->trigger_position ) ] );
+		$this->trigger_position = $args['trigger_position'] ?? self::TRIGGER_POSITION_BOTTOM;
+		$this->classes          = array_merge( [ 'c-video', sprintf( 'c-video--trigger-%s', $this->trigger_position ) ], (array) $args['classes'] ?? [] );
 		$this->attrs            = (array) ( $args['attrs'] ?? [] );
 		$this->video_url        = $args['video_url'] ?? '';
 		$this->video_title      = $args['video_title'] ?? '';
 		$this->trigger_label    = $args['trigger_label'] ?? __( 'Play Video', 'tribe' );
 		$this->thumbnail_url    = $args['thumbnail_url'] ?? '';
 		$this->shim_url         = $args['shim_url'] ?? trailingslashit( get_template_directory_uri() ) . 'assets/img/theme/shims/16x9.png';
-		$this->trigger_position = $args['trigger_position'] ?? self::TRIGGER_POSITION_BOTTOM;
 	}
 
 	public function classes(): string {

--- a/wp-content/themes/core/components/video/Controller.php
+++ b/wp-content/themes/core/components/video/Controller.php
@@ -33,7 +33,7 @@ class Controller extends Abstract_Controller {
 
 	public function __construct( array $args = [] ) {
 		$this->trigger_position = $args['trigger_position'] ?? self::TRIGGER_POSITION_BOTTOM;
-		$this->classes          = array_merge( [ 'c-video', sprintf( 'c-video--trigger-%s', $this->trigger_position ) ], (array) $args['classes'] ?? [] );
+		$this->classes          = array_merge( [ 'c-video', sprintf( 'c-video--trigger-%s', $this->trigger_position ) ], (array) ( $args['classes'] ?? [] ) );
 		$this->attrs            = (array) ( $args['attrs'] ?? [] );
 		$this->video_url        = $args['video_url'] ?? '';
 		$this->video_title      = $args['video_title'] ?? '';

--- a/wp-content/themes/core/twig-components/blocks/cardgrid/cardgrid.twig
+++ b/wp-content/themes/core/twig-components/blocks/cardgrid/cardgrid.twig
@@ -1,10 +1,10 @@
 {# Block: Card Grid #}
 
 <div class="s-content">
-	<div class="g-row g-row--center g-row--col-2--min-medium g-row--col-3--min-full" {{ attrs }}>
+	<div {{ attrs }}>
 
 		{% for card in cards %}
-			<div class="g-col">
+			<div>
 				{{ card }}
 			</div>
 		{% endfor %}

--- a/wp-content/themes/core/twig-components/blocks/content-slider/content-slider.twig
+++ b/wp-content/themes/core/twig-components/blocks/content-slider/content-slider.twig
@@ -1,8 +1,8 @@
 {# Block: Content Slider #}
 
 <div class="s-content">
-	<div class="g-row">
-		<div class="g-col">
+	<div>
+		<div>
 			{{ slider }}
 		</div>
 	</div>

--- a/wp-content/themes/core/twig-components/blocks/tabs/tabs.twig
+++ b/wp-content/themes/core/twig-components/blocks/tabs/tabs.twig
@@ -1,12 +1,11 @@
 {# Block: Tabs #}
 
 <div class="s-content">
-	<div class="g-row"
-		 data-depth="0"
+	<div data-depth="0"
 		 data-name="tabs"
 		 data-livetext
 	>
-		<div class="g-col">
+		<div>
 			{{ tabs }}
 		</div>
 	</div>

--- a/wp-content/themes/core/twig-components/blocks/wysiwyg/wysiwyg.twig
+++ b/wp-content/themes/core/twig-components/blocks/wysiwyg/wysiwyg.twig
@@ -1,13 +1,13 @@
 {# Block: WYSIWYG #}
 
 <div class="s-content">
-	<div class="g-row g-row--center g-row--col-3--min-full"
-			 data-depth="0"
-			 data-name="columns"
-			 data-livetext>
+	<div data-depth="0"
+		data-name="columns"
+		data-livetext
+	>
 
 		{% for col in columns %}
-			<div class="g-col s-sink t-sink"
+			<div class="s-sink t-sink"
 					 data-depth="1"
 					 data-index="{{ loop.index0 }}"
 					 data-name="column_content"


### PR DESCRIPTION
This PR updates components, where appropriate, to allow for the setting of core required classes while allowing for the ability to add additional classes if needed. We have two types of components:

- Components such as link or button where when used, any base classes _should_ be wiped out. They should not and don't need a core set of always present classes and instead classes should be added for each use to allow for the ultimate flexibility for composing FE.
- Components such as video or card where when used, there is a base set of core classes _required_ to accomplish the base component UI. In this case, we only need the ability occasionally to append additional classes.

@dpellenwood this is the resulting PR based on our convo around this. Note that Jonathan, Mike, and I determined that for now, we probably don't need a markup utility. 