### PR TITLE
Implement subheader page title and update text component

### DIFF
--- a/wp-content/plugins/core/src/Templates/Components/Traits/Page_Title.php
+++ b/wp-content/plugins/core/src/Templates/Components/Traits/Page_Title.php
@@ -1,0 +1,35 @@
+<?php
+declare( strict_types=1 );
+
+namespace Tribe\Project\Templates\Components\Traits;
+
+trait Page_Title {
+	public function page_title(): string {
+		if ( is_front_page() ) {
+			return '';
+		}
+
+		// Blog
+		if ( is_home() ) {
+			return __( 'Blog', 'tribe' );
+		}
+
+		// Search
+		if ( is_search() ) {
+			return __( 'Search Results', 'tribe' );
+		}
+
+		// 404
+		if ( is_404() ) {
+			return __( 'Page Not Found (404)', 'tribe' );
+		}
+
+		// Singular
+		if ( is_singular() ) {
+			return get_the_title();
+		}
+
+		// Archives
+		return get_the_archive_title();
+	}
+}

--- a/wp-content/themes/core/components/document/head/Controller.php
+++ b/wp-content/themes/core/components/document/head/Controller.php
@@ -4,8 +4,10 @@ declare( strict_types=1 );
 namespace Tribe\Project\Templates\Components\document\head;
 
 use Tribe\Project\Templates\Components\Abstract_Controller;
+use Tribe\Project\Templates\Components\Traits\Page_Title;
 
 class Controller extends Abstract_Controller {
+	use Page_Title;
 
 	public function name(): string {
 		return get_bloginfo( 'name' );
@@ -13,34 +15,5 @@ class Controller extends Abstract_Controller {
 
 	public function pingback_url(): string {
 		return get_bloginfo( 'pingback_url' );
-	}
-
-	public function page_title(): string {
-		if ( is_front_page() ) {
-			return '';
-		}
-
-		// Blog
-		if ( is_home() ) {
-			return __( 'Blog', 'tribe' );
-		}
-
-		// Search
-		if ( is_search() ) {
-			return __( 'Search Results', 'tribe' );
-		}
-
-		// 404
-		if ( is_404() ) {
-			return __( 'Page Not Found (404)', 'tribe' );
-		}
-
-		// Singular
-		if ( is_singular() ) {
-			return get_the_title();
-		}
-
-		// Archives
-		return get_the_archive_title();
 	}
 }

--- a/wp-content/themes/core/components/header/subheader/Controller.php
+++ b/wp-content/themes/core/components/header/subheader/Controller.php
@@ -4,12 +4,20 @@ declare( strict_types=1 );
 namespace Tribe\Project\Templates\Components\header\subheader;
 
 use Tribe\Project\Templates\Components\Abstract_Controller;
+use Tribe\Project\Templates\Components\Traits\Page_Title;
 
 class Controller extends Abstract_Controller {
+	use Page_Title;
 
-	public function title(): string {
-		// TODO: implement a wrapper/container component
-		// TODO: use the method in head/controller.php?
-		return get_the_title();
+	public function render_title(): string {
+		if ( empty( $this->page_title() ) ) {
+			return '';
+		}
+
+		return tribe_template_part( 'components/text/text', null, [
+			'tag'     => 'h1',
+			'classes' => [ 'page-title', 'h1' ],
+			'content' => $this->page_title(),
+		] );
 	}
 }

--- a/wp-content/themes/core/components/header/subheader/Controller.php
+++ b/wp-content/themes/core/components/header/subheader/Controller.php
@@ -9,7 +9,7 @@ use Tribe\Project\Templates\Components\Traits\Page_Title;
 class Controller extends Abstract_Controller {
 	use Page_Title;
 
-	public function render_title(): string {
+	public function get_title(): string {
 		if ( empty( $this->page_title() ) ) {
 			return '';
 		}

--- a/wp-content/themes/core/components/header/subheader/subheader.php
+++ b/wp-content/themes/core/components/header/subheader/subheader.php
@@ -7,7 +7,7 @@ $c = \Tribe\Project\Templates\Components\header\subheader\Controller::factory();
 
 	<div class="l-container">
 
-		<?php echo $c->render_title(); ?>
+		<?php echo $c->get_title(); ?>
 
 	</div>
 

--- a/wp-content/themes/core/components/header/subheader/subheader.php
+++ b/wp-content/themes/core/components/header/subheader/subheader.php
@@ -7,7 +7,7 @@ $c = \Tribe\Project\Templates\Components\header\subheader\Controller::factory();
 
 	<div class="l-container">
 
-		<?php echo $c->title(); ?>
+		<?php echo $c->render_title(); ?>
 
 	</div>
 

--- a/wp-content/themes/core/components/text/Controller.php
+++ b/wp-content/themes/core/components/text/Controller.php
@@ -31,10 +31,10 @@ class Controller extends Abstract_Controller {
 			$args[$key] = array_merge( $args[$key], $value );
 		}
 
-		$this->tag     = $args['tag'] ?? 'p';
-		$this->classes = (array) ( $args['classes'] ?? [] );
-		$this->attrs   = (array) ( $args['attrs'] ?? [] );
-		$this->content = $args['content'] ?? '';
+		$this->tag     = $args['tag'];
+		$this->classes = (array) $args['classes'];
+		$this->attrs   = (array) $args['attrs'];
+		$this->content = $args['content'];
 	}
 
 	protected function defaults(): array {


### PR DESCRIPTION
This implements the `page_title` method as a trait that is now globally available and makes use of it along with a proper page title in the subheader component. I also updated the text component based on something I missed as part of the greater done component clean up pass.

Dave, I could see us adding some additional args and even variations to subheader in the future, but I think can wait until we start using and finish building out the base theme.