### PR TITLE
Remove Outer `l-container`

### DIFF
--- a/wp-content/themes/core/components/content/single/index/index.php
+++ b/wp-content/themes/core/components/content/single/index/index.php
@@ -7,11 +7,11 @@ $c = \Tribe\Project\Templates\Components\content\single\index\Controller::factor
 
 	<?php echo $c->render_featured_image(); ?>
 
-	<div class="item-single__content s-sink t-sink">
+	<div class="item-single__content s-sink t-sink l-sink l-sink--double">
 		<?php the_content(); ?>
 	</div>
 
-	<footer class="item-single__footer">
+	<footer class="item-single__footer l-container">
 
 		<ul class="item-single__meta">
 

--- a/wp-content/themes/core/components/routes/page/page.php
+++ b/wp-content/themes/core/components/routes/page/page.php
@@ -11,14 +11,8 @@ $c->render_header();
 
 		<?php get_template_part( 'components/header/subheader/subheader' ); ?>
 
-		<div class="l-container">
-
-			<?php echo $c->render_featured_image(); ?>
-
-			<div class="t-sink s-sink l-sink l-sink--double">
-				<?php the_content(); ?>
-			</div>
-
+		<div class="t-sink s-sink l-sink l-sink--double">
+			<?php the_content(); ?>
 		</div>
 
 	</main>


### PR DESCRIPTION
## What does this do/fix?

Remove outer l-container for page & post singles since this has to be done at a different level to accommodate "panel" blocks in the_content.