### PR TITLE
method to consistently parse args in template controllers

### DIFF
--- a/dev/tests/tests/integration/Tribe/Project/Templates/Components/Abstract_ControllerTest.php
+++ b/dev/tests/tests/integration/Tribe/Project/Templates/Components/Abstract_ControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tribe\Project\Templates\Components;
+
+class Abstract_ControllerTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	// Tests
+	public function test_parses_args() {
+		$args = [
+			'one'   => 'this is a string',
+			'two'   => [ 'this', 'is', 'an', 'array' ],
+			'three' => [ 'value' ],
+		];
+
+		$controller = new class( $args ) extends Abstract_Controller {
+			public array $args;
+
+			public function __construct( array $args ) {
+				$this->args = $this->parse_args( $args );
+			}
+
+			protected function defaults(): array {
+				return [
+					'one'   => 'default string',
+					'two'   => [ 'default', 'array' ],
+					'three' => [ 'optional' ],
+					'four'  => 'something',
+				];
+			}
+
+			protected function required(): array {
+				return [
+					'three' => [ 'required' ],
+				];
+			}
+		};
+
+		self::assertEquals( 'this is a string', $controller->args['one'] );
+		self::assertEquals( [ 'this', 'is', 'an', 'array' ], $controller->args['two'] );
+		self::assertEquals( [ 'value', 'required' ], $controller->args['three'] );
+		self::assertEquals( 'something', $controller->args['four'] );
+	}
+}

--- a/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
+++ b/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
@@ -4,6 +4,25 @@ declare( strict_types=1 );
 namespace Tribe\Project\Templates\Components;
 
 abstract class Abstract_Controller {
+
+	protected function parse_args( array $args ): array {
+		$args = wp_parse_args( $args, $this->defaults() );
+
+		foreach ( $this->required() as $key => $value ) {
+			$args[$key] = array_merge( $args[$key], $value );
+		}
+
+		return $args;
+	}
+
+	protected function defaults(): array {
+		return [];
+	}
+
+	protected function required(): array {
+		return [];
+	}
+
 	/**
 	 * @param array $args
 	 *

--- a/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
+++ b/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
@@ -9,7 +9,7 @@ abstract class Abstract_Controller {
 		$args = wp_parse_args( $args, $this->defaults() );
 
 		foreach ( $this->required() as $key => $value ) {
-			$args[$key] = array_merge( $args[$key], $value );
+			$args[ $key ] = array_merge( $args[ $key ], $value );
 		}
 
 		return $args;

--- a/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
+++ b/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
@@ -5,20 +5,48 @@ namespace Tribe\Project\Templates\Components;
 
 abstract class Abstract_Controller {
 
+	/**
+	 * Merge the passed arguments with the default and
+	 * required arguments defined by the controller
+	 *
+	 * @param array $args
+	 *
+	 * @return array
+	 */
 	protected function parse_args( array $args ): array {
 		$args = wp_parse_args( $args, $this->defaults() );
 
 		foreach ( $this->required() as $key => $value ) {
+			if ( ! is_array( $value ) ) {
+				throw new \UnexpectedValueException( __( 'Required arguments should be of the type array', 'tribe' ) );
+			}
 			$args[ $key ] = array_merge( $args[ $key ], $value );
 		}
 
 		return $args;
 	}
 
+	/**
+	 * Default arguments are merged with the passed
+	 * arguments to fill in empty values
+	 *
+	 * @return array
+	 */
 	protected function defaults(): array {
 		return [];
 	}
 
+	/**
+	 * Required arguments should be arrays of values
+	 * that will be merged with values passed in args.
+	 *
+	 * E.g., if a controller accepts optional classes,
+	 * but should also _always_ have a 'special' class
+	 * appended, this would return:
+	 * [ 'classes' => [ 'special' ] ]
+	 *
+	 * @return array[]
+	 */
 	protected function required(): array {
 		return [];
 	}


### PR DESCRIPTION
## What does this do/fix?

Adds methods to the `Abstract_Controller` to support consistently parsing args in subclasses. Next step after merging this is to start applying the pattern to existing classes.

## Tests

Does this have tests?

- [X] Yes
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

