### PR TITLE
Unwrap button component

### DIFF
--- a/wp-content/themes/core/components/button/Button_Controller.php
+++ b/wp-content/themes/core/components/button/Button_Controller.php
@@ -5,55 +5,54 @@ namespace Tribe\Project\Templates\Components\button;
 
 use Tribe\Libs\Utils\Markup_Utils;
 use Tribe\Project\Templates\Components\Abstract_Controller;
+use Tribe\Project\Templates\Components\Deferred_Component;
 
-class Controller extends Abstract_Controller {
+class Button_Controller extends Abstract_Controller {
+	public const TYPE       = 'type';
+	public const CLASSES    = 'classes';
+	public const ATTRS      = 'attrs';
+	public const CONTENT    = 'content';
+	public const ARIA_LABEL = 'aria_label';
+
 	/**
 	 * @var string
 	 */
-	private $type;
+	private string $type;
 	/**
 	 * @var string[]
 	 */
-	private $classes;
+	private array $classes;
 	/**
 	 * @var string[]
 	 */
-	private $attrs;
+	private array $attrs;
 	/**
-	 * @var string
+	 * @var string|Deferred_Component
 	 */
 	private $content;
 	/**
 	 * @var string
 	 */
-	private $aria_label;
+	private string $aria_label;
 
 	public function __construct( array $args = [] ) {
-		$args = wp_parse_args( $args, $this->defaults() );
+		$args = $this->parse_args( $args );
 
-		foreach ( $this->required() as $key => $value ) {
-			$args[$key] = array_merge( $args[$key], $value );
-		}
-
-		$this->classes         = (array) $args['classes'];
-		$this->attrs           = (array) $args['attrs'];
-		$this->type            = $args['type'];
-		$this->aria_label      = $args['aria_label'];
-		$this->content         = $args['content'];
+		$this->classes    = (array) $args[ self::CLASSES ];
+		$this->attrs      = (array) $args[ self::ATTRS ];
+		$this->type       = (string) $args[ self::TYPE ];
+		$this->aria_label = (string) $args[ self::ARIA_LABEL ];
+		$this->content    = $args[ self::CONTENT ];
 	}
 
 	protected function defaults(): array {
 		return [
-			'classes'         => [],
-			'attrs'           => [],
-			'type'            => '',
-			'aria_label'      => '',
-			'content'         => '',
+			self::CLASSES    => [],
+			self::ATTRS      => [],
+			self::TYPE       => '',
+			self::ARIA_LABEL => '',
+			self::CONTENT    => '',
 		];
-	}
-
-	protected function required(): array {
-		return [];
 	}
 
 	public function has_content(): bool {

--- a/wp-content/themes/core/components/button/Controller.php
+++ b/wp-content/themes/core/components/button/Controller.php
@@ -27,18 +27,6 @@ class Controller extends Abstract_Controller {
 	 * @var string
 	 */
 	private $aria_label;
-	/**
-	 * @var string
-	 */
-	public $wrapper_tag;
-	/**
-	 * @var string[]
-	 */
-	private $wrapper_classes;
-	/**
-	 * @var string[]
-	 */
-	private $wrapper_attrs;
 
 	public function __construct( array $args = [] ) {
 		$args = wp_parse_args( $args, $this->defaults() );
@@ -52,9 +40,6 @@ class Controller extends Abstract_Controller {
 		$this->type            = $args['type'];
 		$this->aria_label      = $args['aria_label'];
 		$this->content         = $args['content'];
-		$this->wrapper_tag     = $args['wrapper_tag'];
-		$this->wrapper_classes = (array) $args['wrapper_classes'];
-		$this->wrapper_attrs   = (array) $args['wrapper_attrs'];
 	}
 
 	protected function defaults(): array {
@@ -64,9 +49,6 @@ class Controller extends Abstract_Controller {
 			'type'            => '',
 			'aria_label'      => '',
 			'content'         => '',
-			'wrapper_tag'     => '',
-			'wrapper_classes' => [],
-			'wrapper_attrs'   => [],
 		];
 	}
 
@@ -96,19 +78,5 @@ class Controller extends Abstract_Controller {
 		}
 
 		return Markup_Utils::concat_attrs( $attributes );
-	}
-
-	public function wrapper_tag_open(): string {
-		if ( empty( $this->wrapper_tag ) ) {
-			return '';
-		}
-		return sprintf( '<%s%s %s>', $this->wrapper_tag, Markup_Utils::class_attribute( $this->wrapper_classes ), Markup_Utils::concat_attrs( $this->wrapper_attrs ) );
-	}
-
-	public function wrapper_tag_close(): string {
-		if ( empty( $this->wrapper_tag ) ) {
-			return '';
-		}
-		return sprintf( '</%s>', $this->wrapper_tag );
 	}
 }

--- a/wp-content/themes/core/components/button/button.php
+++ b/wp-content/themes/core/components/button/button.php
@@ -11,14 +11,9 @@ if ( ! $c->has_content() ) {
 	return;
 }
 ?>
-
-<?php echo $c->wrapper_tag_open(); ?>
-
-	<button
-		<?php echo $c->classes(); ?>
-		<?php echo $c->attributes(); ?>
-	>
-		<?php echo $c->content(); ?>
-	</button>
-
-<?php echo $c->wrapper_tag_close(); ?>
+<button
+	<?php echo $c->classes(); ?>
+	<?php echo $c->attributes(); ?>
+>
+	<?php echo $c->content(); ?>
+</button>

--- a/wp-content/themes/core/components/button/button.php
+++ b/wp-content/themes/core/components/button/button.php
@@ -5,7 +5,7 @@ declare( strict_types=1 );
  * @var array $args Arguments passed to the template
  */
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$c = \Tribe\Project\Templates\Components\button\Controller::factory( $args );
+$c = \Tribe\Project\Templates\Components\button\Button_Controller::factory( $args );
 
 if ( ! $c->has_content() ) {
 	return;


### PR DESCRIPTION
## What does this do/fix?

- Removes the wrapper arguments from the button component. Calls to the button component that need a wrapper (none currently exist) should use the container component around it.
- Refactors the button controller class to meet the coding conventions that we've been discussing. Don't like something here? Let's have a conversation about it; this is one possible path, but not the only possible path.

## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because... it is not adding any functionality
- [ ] No, I need help figuring out how to write the tests.

