### PR TITLE
abort container template if empty

### DIFF
--- a/wp-content/themes/core/components/container/container.php
+++ b/wp-content/themes/core/components/container/container.php
@@ -6,11 +6,15 @@ declare( strict_types=1 );
  */
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 $c = \Tribe\Project\Templates\Components\container\Controller::factory( $args );
+$content = $c->content();
+if ( empty( $content ) ) {
+	return;
+}
 ?>
 
 <<?php echo $c->tag(); ?>
 	<?php echo $c->classes(); ?>
 	<?php echo $c->attributes(); ?>
 >
-	<?php echo $c->content(); ?>
+	<?php echo $content; ?>
 </<?php echo $c->tag(); ?>>


### PR DESCRIPTION
## What does this do/fix?

If the container template has no content, abort rendering to avoid an empty container.

