### PR TITLE
Feeture/editable hidden block content

### DIFF
--- a/wp-content/themes/core/assets/css/src/admin/block-editor/blocks/acf.pcss
+++ b/wp-content/themes/core/assets/css/src/admin/block-editor/blocks/acf.pcss
@@ -21,3 +21,41 @@
 		margin-right: auto;
 	}
 }
+
+/* -----------------------------------------------------------------------------
+ * Accordion Block
+ *
+ * Unset hidden accordion row properties for the editor.
+ * ----------------------------------------------------------------------------- */
+
+.wp-block[data-type^="acf/accordion"] {
+
+	.c-accordion__content {
+		display: block;
+		max-height: none;
+		overflow: visible;
+	}
+}
+
+/* -----------------------------------------------------------------------------
+ * Accordion Block
+ *
+ * Unset hidden tabpanel row properties for the editor & provide some separation
+ * to each tabpanel while editing.
+ * ----------------------------------------------------------------------------- */
+
+.wp-block[data-type^="acf/tabs"] {
+
+	.c-tabs__tabpanel {
+		display: block;
+		margin-bottom: var(--spacer-30);
+		padding-bottom: var(--spacer-30);
+		border-bottom: 1px solid var(--color-border);
+
+		&:last-of-type {
+			margin-bottom: 0;
+			padding-bottom: 0;
+			border-bottom: none;
+		}
+	}
+}


### PR DESCRIPTION
## What does this do/fix?

Makes accordion and tabpanel rows all visible to an editor.

For the time being, this is the approach we'll take for hidden repeater content. While our FE scripts for these blocks can run fine in the editor, the ACF blocks scripts don't have powerful enough hooks for us to switch the "active" or visible repeater row when a specific field is focused. Thus, an editor could "switch" to viewing a tab in live preview, but as soon as the contents changes, the preview is refreshed and reverts to the "initial" view.

In time this should be revisited to see if we can find a better/more seamless solution.
