### PR TITLE
remove twig definer from default list in Core

### DIFF
--- a/wp-content/plugins/core/src/Core.php
+++ b/wp-content/plugins/core/src/Core.php
@@ -86,7 +86,6 @@ class Core {
 		'\Tribe\Libs\Queues_Mysql\Mysql_Backend_Definer',
 		'\Tribe\Libs\Required_Page\Required_Page_Definer',
 		'\Tribe\Libs\Settings\Settings_Definer',
-		'\Tribe\Libs\Twig\Twig_Definer',
 		'\Tribe\Libs\Whoops\Whoops_Definer',
 	];
 


### PR DESCRIPTION
## What does this do/fix?

Removes `Twig_Definer` from the default list of tribe-libs packages we instantiate from `Core`.

