### PR TITLE
Feature/acf block class names

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Types/Accordion/Accordion_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Accordion/Accordion_Model.php
@@ -14,6 +14,7 @@ class Accordion_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Accordion_Block_Controller::CLASSES     => $this->getClassName(),
 			Accordion_Block_Controller::LAYOUT      => $this->get( Accordion::LAYOUT, Accordion::LAYOUT_STACKED ),
 			Accordion_Block_Controller::ROWS        => $this->get_accordion_rows(),
 			Accordion_Block_Controller::TITLE       => $this->get( Accordion::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Accordion/Accordion_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Accordion/Accordion_Model.php
@@ -14,7 +14,7 @@ class Accordion_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Accordion_Block_Controller::CLASSES     => $this->getClassName(),
+			Accordion_Block_Controller::CLASSES     => $this->get_classes(),
 			Accordion_Block_Controller::LAYOUT      => $this->get( Accordion::LAYOUT, Accordion::LAYOUT_STACKED ),
 			Accordion_Block_Controller::ROWS        => $this->get_accordion_rows(),
 			Accordion_Block_Controller::TITLE       => $this->get( Accordion::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Base_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Base_Model.php
@@ -6,7 +6,7 @@ abstract class Base_Model {
 	protected string $mode;
 	protected array  $data;
 	protected string $name;
-	protected string $className;
+	protected string $classes;
 
 	abstract public function get_data(): array;
 
@@ -16,10 +16,10 @@ abstract class Base_Model {
 	 * @param $block
 	 */
 	public function __construct( $block ) {
-		$this->mode      = $block['mode'] ?? 'preview';
-		$this->data      = $block['data'] ?? [];
-		$this->name      = $block['name'] ? str_replace( 'acf/', '', $block['name'] ) : '';
-		$this->className = $block['className'] ?? '';
+		$this->mode    = $block['mode'] ?? 'preview';
+		$this->data    = $block['data'] ?? [];
+		$this->name    = $block['name'] ? str_replace( 'acf/', '', $block['name'] ) : '';
+		$this->classes = $block['className'] ?? '';
 	}
 
 	/**
@@ -42,7 +42,7 @@ abstract class Base_Model {
 	 *
 	 * @return array
 	 */
-	public function getClassName(): array {
-		return explode( ' ', $this->className );
+	public function get_classes(): array {
+		return explode( ' ', $this->classes );
 	}
 }

--- a/wp-content/plugins/core/src/Blocks/Types/Base_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Base_Model.php
@@ -4,8 +4,9 @@ namespace Tribe\Project\Blocks\Types;
 
 abstract class Base_Model {
 	protected string $mode;
-	protected array $data;
+	protected array  $data;
 	protected string $name;
+	protected string $className;
 
 	abstract public function get_data(): array;
 
@@ -15,9 +16,10 @@ abstract class Base_Model {
 	 * @param $block
 	 */
 	public function __construct( $block ) {
-		$this->mode = $block[ 'mode' ] ?? 'preview';
-		$this->data = $block[ 'data' ] ?? [];
-		$this->name = $block[ 'name' ] ? str_replace( 'acf/', '', $block[ 'name' ] ) : '';
+		$this->mode      = $block['mode'] ?? 'preview';
+		$this->data      = $block['data'] ?? [];
+		$this->name      = $block['name'] ? str_replace( 'acf/', '', $block['name'] ) : '';
+		$this->className = $block['className'] ?? '';
 	}
 
 	/**
@@ -33,5 +35,14 @@ abstract class Base_Model {
 		return ! empty( $value )
 			? $value
 			: $default;
+	}
+
+	/**
+	 * Get the "Additional Class Names" value from the block editor.
+	 *
+	 * @return array
+	 */
+	public function getClassName(): array {
+		return explode( ' ', $this->className );
 	}
 }

--- a/wp-content/plugins/core/src/Blocks/Types/Buttons/Buttons_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Buttons/Buttons_Model.php
@@ -12,7 +12,7 @@ class Buttons_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Buttons_Block_Controller::CLASSES => $this->getClassName(),
+			Buttons_Block_Controller::CLASSES => $this->get_classes(),
 			Buttons_Block_Controller::BUTTONS => $this->get( Buttons::BUTTONS, [] ),
 		];
 	}

--- a/wp-content/plugins/core/src/Blocks/Types/Buttons/Buttons_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Buttons/Buttons_Model.php
@@ -12,6 +12,7 @@ class Buttons_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Buttons_Block_Controller::CLASSES => $this->getClassName(),
 			Buttons_Block_Controller::BUTTONS => $this->get( Buttons::BUTTONS, [] ),
 		];
 	}

--- a/wp-content/plugins/core/src/Blocks/Types/Hero/Hero_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Hero/Hero_Model.php
@@ -13,7 +13,7 @@ class Hero_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Hero_Block_Controller::CLASSES     => $this->getClassName(),
+			Hero_Block_Controller::CLASSES     => $this->get_classes(),
 			Hero_Block_Controller::LAYOUT      => $this->get( Hero::LAYOUT, Hero::LAYOUT_LEFT ),
 			Hero_Block_Controller::MEDIA       => $this->get( Hero::IMAGE, 0 ),
 			Hero_Block_Controller::TITLE       => $this->get( Hero::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Hero/Hero_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Hero/Hero_Model.php
@@ -13,6 +13,7 @@ class Hero_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Hero_Block_Controller::CLASSES     => $this->getClassName(),
 			Hero_Block_Controller::LAYOUT      => $this->get( Hero::LAYOUT, Hero::LAYOUT_LEFT ),
 			Hero_Block_Controller::MEDIA       => $this->get( Hero::IMAGE, 0 ),
 			Hero_Block_Controller::TITLE       => $this->get( Hero::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Interstitial/Interstitial_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Interstitial/Interstitial_Model.php
@@ -13,10 +13,11 @@ class Interstitial_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Interstitial_Block_Controller::TITLE  => $this->get( Interstitial::TITLE, '' ),
-			Interstitial_Block_Controller::CTA    => $this->get_cta_args(),
-			Interstitial_Block_Controller::LAYOUT => $this->get( Interstitial::LAYOUT, '' ),
-			Interstitial_Block_Controller::MEDIA  => $this->get( Interstitial::IMAGE, 0 ),
+			Interstitial_Block_Controller::CLASSES => $this->getClassName(),
+			Interstitial_Block_Controller::TITLE   => $this->get( Interstitial::TITLE, '' ),
+			Interstitial_Block_Controller::CTA     => $this->get_cta_args(),
+			Interstitial_Block_Controller::LAYOUT  => $this->get( Interstitial::LAYOUT, '' ),
+			Interstitial_Block_Controller::MEDIA   => $this->get( Interstitial::IMAGE, 0 ),
 		];
 	}
 

--- a/wp-content/plugins/core/src/Blocks/Types/Interstitial/Interstitial_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Interstitial/Interstitial_Model.php
@@ -13,7 +13,7 @@ class Interstitial_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Interstitial_Block_Controller::CLASSES => $this->getClassName(),
+			Interstitial_Block_Controller::CLASSES => $this->get_classes(),
 			Interstitial_Block_Controller::TITLE   => $this->get( Interstitial::TITLE, '' ),
 			Interstitial_Block_Controller::CTA     => $this->get_cta_args(),
 			Interstitial_Block_Controller::LAYOUT  => $this->get( Interstitial::LAYOUT, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
@@ -13,6 +13,7 @@ class Lead_Form_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Lead_Form_Block_Controller::CLASSES     => $this->getClassName(),
 			Lead_Form_Block_Controller::LAYOUT      => $this->get( Lead_Form::LAYOUT, Lead_Form::LAYOUT_CENTER ),
 			Lead_Form_Block_Controller::WIDTH       => $this->get( Lead_Form::WIDTH, Lead_Form::WIDTH_GRID ),
 			Lead_Form_Block_Controller::TITLE       => $this->get( Lead_Form::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
@@ -13,7 +13,7 @@ class Lead_Form_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Lead_Form_Block_Controller::CLASSES     => $this->getClassName(),
+			Lead_Form_Block_Controller::CLASSES     => $this->get_classes(),
 			Lead_Form_Block_Controller::LAYOUT      => $this->get( Lead_Form::LAYOUT, Lead_Form::LAYOUT_CENTER ),
 			Lead_Form_Block_Controller::WIDTH       => $this->get( Lead_Form::WIDTH, Lead_Form::WIDTH_GRID ),
 			Lead_Form_Block_Controller::TITLE       => $this->get( Lead_Form::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Links/Links_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Links/Links_Model.php
@@ -13,7 +13,7 @@ class Links_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Links_Block_Controller::CLASSES     => $this->getClassName(),
+			Links_Block_Controller::CLASSES     => $this->get_classes(),
 			Links_Block_Controller::TITLE       => $this->get( Links::TITLE, '' ),
 			Links_Block_Controller::LEADIN      => $this->get( Links::LEAD_IN, '' ),
 			Links_Block_Controller::DESCRIPTION => $this->get( Links::DESCRIPTION, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Links/Links_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Links/Links_Model.php
@@ -13,6 +13,7 @@ class Links_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Links_Block_Controller::CLASSES     => $this->getClassName(),
 			Links_Block_Controller::TITLE       => $this->get( Links::TITLE, '' ),
 			Links_Block_Controller::LEADIN      => $this->get( Links::LEAD_IN, '' ),
 			Links_Block_Controller::DESCRIPTION => $this->get( Links::DESCRIPTION, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Logos/Logos_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Logos/Logos_Model.php
@@ -13,6 +13,7 @@ class Logos_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Logos_Block_Controller::CLASSES     => $this->getClassName(),
 			Logos_Block_Controller::TITLE       => $this->get( Logos::TITLE, '' ),
 			Logos_Block_Controller::LEADIN      => $this->get( Logos::LEAD_IN, '' ),
 			Logos_Block_Controller::DESCRIPTION => $this->get( Logos::DESCRIPTION, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Logos/Logos_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Logos/Logos_Model.php
@@ -13,7 +13,7 @@ class Logos_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Logos_Block_Controller::CLASSES     => $this->getClassName(),
+			Logos_Block_Controller::CLASSES     => $this->get_classes(),
 			Logos_Block_Controller::TITLE       => $this->get( Logos::TITLE, '' ),
 			Logos_Block_Controller::LEADIN      => $this->get( Logos::LEAD_IN, '' ),
 			Logos_Block_Controller::DESCRIPTION => $this->get( Logos::DESCRIPTION, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Media_Text/Media_Text_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Media_Text/Media_Text_Model.php
@@ -13,7 +13,7 @@ class Media_Text_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Media_Text_Block_Controller::CLASSES     => $this->getClassName(),
+			Media_Text_Block_Controller::CLASSES     => $this->get_classes(),
 			Media_Text_Block_Controller::LAYOUT      => $this->get( Media_Text::LAYOUT, Media_Text::MEDIA_LEFT ),
 			Media_Text_Block_Controller::WIDTH       => $this->get( Media_Text::WIDTH, Media_Text::WIDTH_GRID ),
 			Media_Text_Block_Controller::TITLE       => $this->get( Media_Text::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Media_Text/Media_Text_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Media_Text/Media_Text_Model.php
@@ -13,6 +13,7 @@ class Media_Text_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Media_Text_Block_Controller::CLASSES     => $this->getClassName(),
 			Media_Text_Block_Controller::LAYOUT      => $this->get( Media_Text::LAYOUT, Media_Text::MEDIA_LEFT ),
 			Media_Text_Block_Controller::WIDTH       => $this->get( Media_Text::WIDTH, Media_Text::WIDTH_GRID ),
 			Media_Text_Block_Controller::TITLE       => $this->get( Media_Text::TITLE, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Post_List/Post_List_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Post_List/Post_List_Model.php
@@ -14,6 +14,7 @@ class Post_List_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Post_List_Controller::CLASSES     => $this->getClassName(),
 			Post_List_Controller::LAYOUT      => $this->get(
 				Post_List::LAYOUT,
 				Post_List::LAYOUT_STACKED

--- a/wp-content/plugins/core/src/Blocks/Types/Post_List/Post_List_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Post_List/Post_List_Model.php
@@ -14,7 +14,7 @@ class Post_List_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Post_List_Controller::CLASSES     => $this->getClassName(),
+			Post_List_Controller::CLASSES     => $this->get_classes(),
 			Post_List_Controller::LAYOUT      => $this->get(
 				Post_List::LAYOUT,
 				Post_List::LAYOUT_STACKED

--- a/wp-content/plugins/core/src/Blocks/Types/Quote/Quote_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Quote/Quote_Model.php
@@ -12,7 +12,7 @@ class Quote_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Quote_Block_Controller::CLASSES    => $this->getClassName(),
+			Quote_Block_Controller::CLASSES    => $this->get_classes(),
 			Quote_Block_Controller::CITE_TITLE => $this->get( Quote::CITE_TITLE, '' ),
 			Quote_Block_Controller::CITE_NAME  => $this->get( Quote::CITE_NAME, '' ),
 			Quote_Block_Controller::CITE_IMAGE => $this->get( Quote::CITE_IMAGE, 0 ),

--- a/wp-content/plugins/core/src/Blocks/Types/Quote/Quote_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Quote/Quote_Model.php
@@ -12,6 +12,7 @@ class Quote_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Quote_Block_Controller::CLASSES    => $this->getClassName(),
 			Quote_Block_Controller::CITE_TITLE => $this->get( Quote::CITE_TITLE, '' ),
 			Quote_Block_Controller::CITE_NAME  => $this->get( Quote::CITE_NAME, '' ),
 			Quote_Block_Controller::CITE_IMAGE => $this->get( Quote::CITE_IMAGE, 0 ),

--- a/wp-content/plugins/core/src/Blocks/Types/Stats/Stats_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Stats/Stats_Model.php
@@ -14,6 +14,7 @@ class Stats_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Stats_Block_Controller::CLASSES       => $this->getClassName(),
 			Stats_Block_Controller::LAYOUT        => $this->get( Stats::LAYOUT, Stats::LAYOUT_STACKED ),
 			Stats_Block_Controller::CONTENT_ALIGN => $this->get( Stats::CONTENT_ALIGN, Stats::CONTENT_ALIGN_CENTER ),
 			Stats_Block_Controller::DIVIDERS      => $this->get( Stats::DIVIDERS, Stats::DIVIDERS_SHOW ),

--- a/wp-content/plugins/core/src/Blocks/Types/Stats/Stats_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Stats/Stats_Model.php
@@ -14,7 +14,7 @@ class Stats_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Stats_Block_Controller::CLASSES       => $this->getClassName(),
+			Stats_Block_Controller::CLASSES       => $this->get_classes(),
 			Stats_Block_Controller::LAYOUT        => $this->get( Stats::LAYOUT, Stats::LAYOUT_STACKED ),
 			Stats_Block_Controller::CONTENT_ALIGN => $this->get( Stats::CONTENT_ALIGN, Stats::CONTENT_ALIGN_CENTER ),
 			Stats_Block_Controller::DIVIDERS      => $this->get( Stats::DIVIDERS, Stats::DIVIDERS_SHOW ),

--- a/wp-content/plugins/core/src/Blocks/Types/Tabs/Tabs_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Tabs/Tabs_Model.php
@@ -14,6 +14,7 @@ class Tabs_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
+			Tabs_Block_Controller::CLASSES     => $this->getClassName(),
 			Tabs_Block_Controller::LAYOUT      => $this->get( Tabs::LAYOUT, Tabs::LAYOUT_HORIZONTAL ),
 			Tabs_Block_Controller::TITLE       => $this->get( Tabs::TITLE, '' ),
 			Tabs_Block_Controller::LEADIN      => $this->get( Tabs::LEAD_IN, '' ),

--- a/wp-content/plugins/core/src/Blocks/Types/Tabs/Tabs_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Tabs/Tabs_Model.php
@@ -14,7 +14,7 @@ class Tabs_Model extends Base_Model {
 	 */
 	public function get_data(): array {
 		return [
-			Tabs_Block_Controller::CLASSES     => $this->getClassName(),
+			Tabs_Block_Controller::CLASSES     => $this->get_classes(),
 			Tabs_Block_Controller::LAYOUT      => $this->get( Tabs::LAYOUT, Tabs::LAYOUT_HORIZONTAL ),
 			Tabs_Block_Controller::TITLE       => $this->get( Tabs::TITLE, '' ),
 			Tabs_Block_Controller::LEADIN      => $this->get( Tabs::LEAD_IN, '' ),


### PR DESCRIPTION
## What does this do/fix?

Adds support for WP Core's [Additional Classes](http://p.tri.be/nJNqxw) field to be applied to our ACF blocks.

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

