### PR TITLE
Feature/drop tertiary button styles

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Types/Buttons/Buttons.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Buttons/Buttons.php
@@ -19,7 +19,7 @@ class Buttons extends Block_Config {
 
 	public const STYLE_PRIMARY   = 'primary';
 	public const STYLE_SECONDARY = 'secondary';
-	public const STYLE_TERTIARY  = 'tertiary';
+	public const STYLE_CTA       = 'cta';
 
 	public function add_block() {
 		$this->set_block( new Block( self::NAME, [
@@ -67,7 +67,7 @@ class Buttons extends Block_Config {
 			'choices'         => [
 				self::STYLE_PRIMARY   => __( 'Primary', 'tribe' ),
 				self::STYLE_SECONDARY => __( 'Secondary', 'tribe' ),
-				self::STYLE_TERTIARY  => __( 'Tertiary', 'tribe' ),
+				self::STYLE_CTA       => __( 'Text CTA', 'tribe' ),
 			],
 			'default_value'   => self::STYLE_PRIMARY,
 			'multiple'        => 0,

--- a/wp-content/themes/core/assets/css/src/theme/actions/_mixins.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/actions/_mixins.pcss
@@ -132,36 +132,6 @@
 }
 
 /* -----------------------------------------------------------------------------
- * Button: Tertiary
- * ----------------------------------------------------------------------------- */
-
-@define-mixin a-btn-tertiary {
-	@mixin a-btn-global;
-
-	color: var(--color-white);
-	background-color: var(--color-secondary);
-
-	&:focus,
-	&:active,
-	&:hover {
-		color: var(--color-white);
-		background-color: var(--color-secondary-70);
-	}
-
-	/* CASE: Disabled */
-	&[disabled],
-	&.is-disabled {
-		background-color: var(--color-grey);
-
-		&:focus,
-		&:active,
-		&:hover {
-			background-color: var(--color-grey);
-		}
-	}
-}
-
-/* -----------------------------------------------------------------------------
  * Button: Icon Before
  * ----------------------------------------------------------------------------- */
 

--- a/wp-content/themes/core/assets/css/src/theme/actions/actions.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/actions/actions.pcss
@@ -46,26 +46,6 @@ a.a-btn-secondary,
 
 /* -----------------------------------------------------------------------------
  *
- * Button: Tertiary
- *
- * Notes:
- * + Has secondary color for background.
- * + On hover/focus animate background color
- *
- * Example:
- * <button class="a-btn-tertiary">...</button>
- * <a href="#" class="a-btn-tertiary">...</a>
- *
- * ----------------------------------------------------------------------------- */
-
-.a-btn-tertiary,
-a.a-btn-tertiary,
-.t-sink a.a-btn-tertiary {
-	@mixin a-btn-tertiary;
-}
-
-/* -----------------------------------------------------------------------------
- *
  * Button: Icon Before
  *
  * Notes:

--- a/wp-content/themes/core/components/blocks/buttons/Buttons_Block_Controller.php
+++ b/wp-content/themes/core/components/blocks/buttons/Buttons_Block_Controller.php
@@ -94,10 +94,16 @@ class Buttons_Block_Controller extends Abstract_Controller {
 	private function get_button_classes( $button ): array {
 		$classes = [ 'b-buttons__button' ];
 
-		if ( $button[ Buttons::BUTTON_STYLE ] === Buttons::STYLE_PRIMARY ) {
-			$classes[] = 'a-btn';
-		} else {
-			$classes[] = sprintf( 'a-btn-%s', $button[ Buttons::BUTTON_STYLE ] );
+		switch ( $button[ Buttons::BUTTON_STYLE ] ) {
+			case Buttons::STYLE_SECONDARY:
+				$classes[] = sprintf( 'a-btn-%s', $button[ Buttons::BUTTON_STYLE ] );
+				break;
+			case Buttons::STYLE_CTA:
+				$classes[] = 'a-cta';
+				break;
+			default:
+				$classes[] = 'a-btn';
+				break;
 		}
 
 		if ( ! empty( $button[ Buttons::BUTTON_CLASSES ] ) ) {


### PR DESCRIPTION
## What does this do/fix?
* Replaces tertiary button style with CTA sytle in the Buttons block.
* Drops the tertiary button styles from the theme.

## Tests
Does this have tests?
- [ ] Yes
- [x] No, this doesn't need tests because I'm removing code.
- [ ] No, I need help figuring out how to write the tests.

