### PR TITLE
Updates slug name for Core Custom HTML block.

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -77,7 +77,7 @@ class Blocks_Definer implements Definer_Interface {
 				'core/video',
 				'core/code',
 				'core/classic',
-				'core/custom-html',
+				'core/html',
 				'core/preformatted',
 				'core/quote',
 				'core/table',


### PR DESCRIPTION
## What does this do/fix?

Updates the slug from `core/custom-html` to `core/html` in order to give access to the core HTML block. 


## QA

Links to relevant issues
- #626 

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

