### PR TITLE
SQONE-498 Add Tota11y plugin for dev & testing. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,8 @@
     "wpackagist-plugin/safe-svg": "1.9.9",
     "wpackagist-plugin/the-events-calendar": "5.1.6",
     "wpackagist-plugin/user-switching": "1.5.5",
-    "wpackagist-plugin/wordpress-seo": "14.9"
+    "wpackagist-plugin/wordpress-seo": "14.9",
+    "wpackagist-plugin/wp-tota11y": "^1.1"
   },
   "require-dev": {
     "automattic/phpcs-neutron-standard": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffcc927f247d2ca730d65ce2eaf03c00",
+    "content-hash": "f5b0e95a5c3092344f685d4c836c3242",
     "packages": [
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
@@ -3192,6 +3192,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wordpress-seo/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-tota11y",
+            "version": "1.1.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-tota11y/",
+                "reference": "tags/1.1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-tota11y.1.1.1.zip"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-tota11y/"
         }
     ],
     "packages-dev": [

--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -40,6 +40,7 @@ class Force_Plugin_Activation {
 		'rewrite-rules-inspector/rewrite-rules-inspector.php',
 		'wp-log-in-browser/wp-log-in-browser.php',
 		'wp-xhprof-profiler/xhprof-profiler.php',
+		'wp-tota11y/wp-tota11y.php',
 	];
 
 	/**
@@ -58,6 +59,7 @@ class Force_Plugin_Activation {
 		'rewrite-rules-inspector/rewrite-rules-inspector.php',
 		'wp-log-in-browser/wp-log-in-browser.php',
 		'wp-xhprof-profiler/xhprof-profiler.php',
+		'wp-tota11y/wp-tota11y.php',
 	];
 
 


### PR DESCRIPTION
## What does this do/fix?
Adds the WP Tota11y plugin for dev & QA. We used to inject the script as an NPM package and separate JS equeue as part of the SquareOne build. This was removed when the build system was refactored as part of FF.  QA has asked that we bring it back as it's useful for QA'ing. And, frankly, it's helpful for dev as well.

I'm proposing we just rely on a 3rd-party plugin for this rather than making it a part of the Sq1 build system. As it is setup in this PR, the plugin will be force-deactivated if WP_DEBUG is false (or Production), and it will be available to network admins to activate only (in multisite).

## Tests
Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's just a plugin addition.
- [ ] No, I need help figuring out how to write the tests.

