### PR TITLE
rewrite component docs for new paradigm

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -5,14 +5,6 @@ when it comes to the scope of features it offers) and are seeing references to �
 codebase. They seem…powerful I guess? At the very least they seem _complicated_ which sometimes is a good indication
 that something is powerful even if it’s confusing. 
 
-To be honest, Components are something that can take a bit of time to wrap your head around. I’m one of the main
-architects of the system and I still find myself scratching my head from time to time. Common sense would seem to
-indicate that perhaps that means we need to refactor them, but I’m a developer so common sense is not my strong suit,
-so instead I’ll laugh in the face of logic and double down on the system.
-
-(In all seriousness, I really do think our Components system is worthwhile once you get a good handle on it, and I
-hope this guide helps assist it reaching a good comfort level with them).
-
 So in the spirit of clarifying what can be a mystifying system, I want to walk through how Components work,
 and how we can use them in our code to provide better, more consistent templating for the Front End of a site. 
 
@@ -50,17 +42,15 @@ focus on providing an existing Button component with the data it needs to render
 Now that I’ve enticed you with talk of LEGO and creations and pie-in-the-sky aspirations of boundless imagination,
 let’s get down to the brass tacks of components.
 
-We have five separate, related pieces to consider for a component. Fortunately, many of have enough fingers to count
+We have four separate, related pieces to consider for a component. Fortunately, many of us have enough fingers to count
 that high, so we should be able to make it through. Here they all are in a list we can refer back to later:
 
 1. Template
-1. Context
 1. Controller
 1. CSS
 1. JavaScript
 
-We managed to name three of the five to start with a "C", just like "C"omponent. Truly a sign that we're on the right
-track. Let's dive in, one at a time, walking through a contrived (there's that "C" again) example to showcase the
+Let's dive in, one at a time, walking through a contrived example to showcase the
 salient details. Here's the HTML we want to generate from a Button component:
 
 ```html
@@ -69,25 +59,35 @@ salient details. Here's the HTML we want to generate from a Button component:
 </button>
 ```
 
-## Twig Templates
+## HTML Templates
 
-Our Button component's directory will contain a Twig file named `button.twig`. It will looks like:
+Our Button component's directory will contain a PHP file named `button.twig`. It will look like:
 
-```twig
-<button {{ classes }} {{ attrs }}>
-	{{ content }}
+```php
+<?php
+declare( strict_types=1 );
+
+/**
+ * @var array $args Arguments passed to the template
+ */
+// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$c = \Tribe\Example\Templates\Components\button\Button_Controller\Button_Controller::factory( $args );
+?>
+<button <?php echo $c->get_classes(); ?> <?php echo $c->get_attrs(); ?>>
+	<?php echo $c->get_content(); ?>
 </button>
 ```
 
-Pretty simple eh? So if you’re not familiar with Twig, the `{{ foo }}` syntax is simply how Twig echoes variables.
-So `classes` and `attrs` and `content` are all just variables that are passed to the Twig file, which it in turn
-is echoing. 
+The first few lines contain some boilerplate that we'll see at the top of very template:
 
-You’ll perhaps notice, then, that this Twig file is…really mostly just echoing variables. And you’d be correct!
+1. The `$args` array will contain arguments that have been passed into the template. Note that phpcs doesn't
+   know about it, so include a comment to tell it that we know what we're doing.
+2. `$c = Button_Controller::factory( $args );` instantiates the relevant controller for the template.
+
+After that, the template is echoing HTML and strings that it gets from the controller.
 Components are all about injecting the data where it needs to go. A good Component simply takes what it’s given
 and gives it structure. In fact, that’s one of the driving principles behind Components - it separates Logic from
-Layout. Controllers let PHP do what it does best (calculate things) while Twig lets HTML do what it does best
-(display things). This system avoids the mess that can result from a PHP file mixing logic in with display. We’ve
+Layout. This system avoids the mess that can result from a PHP file mixing logic in with display. We’ve
 all seen this before:
 
 ```php
@@ -106,355 +106,320 @@ all seen this before:
 </button>
 ```
 
-That physically hurt me to type out. Isn’t the Component Twig markup much cleaner and easier to parse? I sure think so,
-but then again I did make it so I might be biased.
+## Controllers
 
-For more complex templates, we have the full range of Twig tags, filters, and functions available to us in our
-templates. Consult the [Twig Documentation](https://twig.symfony.com/doc/3.x/) for reference.
-
-We have also added our own extension to Twig to bring some of WordPress's escaping and internationalization tools into
-our templates. See `\Tribe\Libs\Twig\Extension` for an easily skimable list of filters and functions available. This
-example demonstrates both the string translation function and its filtering through `esc_html`:
-
-```twig
-<p class="comments__none">{{ __( 'Comments are closed.' )|esc_html }}</p>
-```
-
-## Contexts
-
-At this point, you've fallen in love with Twig. No logic, no database queries, just echoing variables with a lot of
-curly brackets. But…surely there's more to it than that. We still have four fingers left. For our next trick, we need to
-tell Twig to render the template with our data. This is where a `Context` class comes into play.
-
-A `Context` is a class responsible for receiving the data and passing it along to Twig for rendering. Let's take a
-look at one for our Button component.
+Our template echoes data that it gets from the Controller. Any logic surrounding that data should be delegated to
+the Controller. Here's what a controller for our button might look like:
 
 ```php
 <?php
+declare( strict_types=1 );
 
-namespace Tribe\Example\Templates\Components;
+namespace Tribe\Example\Templates\Components\button;
 
-/**
- * Class Button
- *
- * @property string   $type
- * @property string   $aria_label
- * @property string[] $classes
- * @property string[] $attrs
- * @property string   $content
- */
-class Button extends \Tribe\Project\Templates\Components\Context {
+use Tribe\Libs\Utils\Markup_Utils;
+use Tribe\Project\Templates\Components\Deferred_Component;
+
+class Button_Controller extends \Tribe\Project\Templates\Components\Abstract_Controller {
 	public const TYPE       = 'type';
-	public const ARIA_LABEL = 'aria_label';
 	public const CLASSES    = 'classes';
 	public const ATTRS      = 'attrs';
 	public const CONTENT    = 'content';
+	public const ARIA_LABEL = 'aria_label';
 
-	protected $path = __DIR__ . '/button.twig';
+	private string $content;
+	private string $type;
+	private array  $classes;
+	private array  $attrs;
+	private string $aria_label;
 
-	protected $properties = [
-		self::TYPE       => [
-			self::DEFAULT => 'button',
-		],
-		self::ARIA_LABEL => [
-			self::DEFAULT => '',
-		],
-		self::CLASSES    => [
-			self::DEFAULT       => [],
-			self::MERGE_CLASSES => [],
-		],
-		self::ATTRS      => [
-			self::DEFAULT => [],
-			self::MERGE_ATTRIBUTES => [],
-		],
-		self::CONTENT    => [
-			self::DEFAULT => '',
-		],
-	];
+	public function __construct( array $args = [] ) {
+		$args = $this->parse_args( $args );
 
-	public function get_data(): array {
+		$this->classes    = (array) $args[ self::CLASSES ];
+		$this->attrs      = (array) $args[ self::ATTRS ];
+		$this->type       = (string) $args[ self::TYPE ];
+		$this->aria_label = (string) $args[ self::ARIA_LABEL ];
+		$this->content    = $args[ self::CONTENT ];
+	}
+
+	protected function defaults(): array {
+		return [
+			self::CLASSES    => [],
+			self::ATTRS      => [],
+			self::TYPE       => '',
+			self::ARIA_LABEL => '',
+			self::CONTENT    => '',
+		];
+	}
+
+	protected function required(): array {
+		return [
+          self::CLASSES => [ 'this-is-a-button' ],
+        ];
+	}
+
+	public function has_content(): bool {
+		return ! empty( $this->content );
+	}
+
+	public function get_content(): string {
+		return $this->content;
+	}
+
+	public function get_classes(): string {
+		return Markup_Utils::class_attribute( $this->classes );
+	}
+
+	public function get_attrs(): string {
+		$attributes = $this->attrs;
+
 		if ( $this->type ) {
-			$this->properties[ self::ATTRS ][ self::VALUE ]['type'] = $this->type;
+			$attributes['type'] = $this->type;
 		}
 
 		if ( $this->aria_label ) {
-			$this->properties[ self::ATTRS ][ self::VALUE ]['aria-label'] = $this->aria_label;
+			$attributes['aria-label'] = $this->aria_label;
 		}
 
-		return parent::get_data();
+		return Markup_Utils::concat_attrs( $attributes );
 	}
 }
+
 ```
 
-There's a lot here, so let's unpack it one piece at a time.
+There's a lot here, so let's unpack one piece at a time.
 
 ```php
-class Button extends \Tribe\Project\Templates\Components\Context {}
+class Button_Controller extends \Tribe\Project\Templates\Components\Abstract_Controller {}
 ```
 
-Our `Context` extends `\Tribe\Project\Templates\Components\Context`. This abstract base class provides much of the
-functionality that we're depending on. Nearly everything else is configuration.
+Our `Button_Controller` extends `Abstract_Controller`. This abstract base class provides some of the structure and
+shared functionality that all of our controllers depend on.
 
 ```php
 public const TYPE       = 'type';
-public const ARIA_LABEL = 'aria_label';
 public const CLASSES    = 'classes';
 public const ATTRS      = 'attrs';
 public const CONTENT    = 'content';
+public const ARIA_LABEL = 'aria_label';
 ```
 
-A bunch of constants! You’ll recognize this from all the other SquareOne code you’ve looked at. We _love_ constants.
+A bunch of constants! You’ll recognize this from all the other SquareOne code you’ve looked at. We love constants.
 And who wouldn’t? They let us define strings right within a Class and reference those strings in other classes when
-needed. Goodbye hardcoding! Goodbye search-and-replace-all-instances-whoops-I-forgot-one-now-the-site-is-white-screening-time-to-update-my-resume!
-Constants are great.  
+needed. Goodbye hardcoding! Goodbye search-and-replace-all-instances-whoops-I-forgot-one-now-the-site-is-white
+-screening-time-to-update-my-resume! Constants are great.
 
-We set up constants for all the variable names we’ll eventually pass to the Twig File. This is handy for a couple
-reasons - first, it allows us to use an IDE’s autocomplete when instantiating this Context (more on that later).
-Second, it acts as a sort of reference for what this Context accepts as options and returns as variables. Handy!
-
+We set up constants for the names of all arguments that might be passed to our temlates.. This is handy for a couple
+reasons - first, it allows us to use an IDE’s autocomplete when instantiating requesting this component (more on that
+later). Second, it acts as a sort of reference for what this component accepts as options.
+ 
 ```php
-protected $path = __DIR__ . '/button.twig';
+private string $content;
+private string $type;
+private array  $classes;
+private array  $attrs;
+private string $aria_label;
 ```
 
-The `$path` tells our `Context` how to find the Twig template it is going to load. Every Component Controller _needs_
-one of these constants. Without it, it is nothing. Think of this as the Garfunkle to Paul Simon. Just useless by
-itself. So instead we point to a Twig Template to use to render our data we’re setting up here.
+Following the constants are the properties of our controller class. These will often (but not quite always) correspond
+to the arguments the component accepts. Some properties, like `$classes` and `$attrs`, will be common to almost all
+components. Others depend on the needs of this particular component.
+
+Wherever possible, properties should be private and typed. If it may have multiple types, give it a docblock to
+specify all of the valid types.
 
 ```php
-protected $properties = [
-    self::TYPE       => [
-        self::DEFAULT => 'button',
-    ],
-    self::ARIA_LABEL => [
-        self::DEFAULT => '',
-    ],
-    self::CLASSES    => [
-        self::DEFAULT       => [],
-        self::MERGE_CLASSES => [],
-    ],
-    self::ATTRS      => [
-        self::DEFAULT => [],
-        self::MERGE_ATTRIBUTES => [],
-    ],
-    self::CONTENT    => [
-        self::DEFAULT => '',
-    ],
-];
+public function __construct( array $args = [] ) {
+    $args = $this->parse_args( $args );
+
+    $this->classes    = (array) $args[ self::CLASSES ];
+    $this->attrs      = (array) $args[ self::ATTRS ];
+    $this->type       = (string) $args[ self::TYPE ];
+    $this->aria_label = (string) $args[ self::ARIA_LABEL ];
+    $this->content    = $args[ self::CONTENT ];
+}
 ```
 
-The giant `$properties` array looks a little scary, but it follows a consistent pattern you'll get used to. Each of
-these properties corresponds to data that should be passed to this Context when it is instantiated. Each property
-has an array of configuration options, the most common of which is the default value (`self::DEFAULT`). You'll
-usually see two other notable options:
-
-`self::MERGE_CLASSES => [ 'some', 'classes' ]`: This tells the Context that it should merge the values from this array
-with the values from the given parameter to build a class attribute.
-
-`self::MERGE_ATTRIBUTES => [ 'data-js' => 'something' ]`: This tells the Context that it should merge this array with
-the values from the given parameter to build a string of HTML attributes.
-
-Jumping back up for a minute:
+The constructor for our controller is responsible for mapping the arguments we receive to those properties.
+`parse_args()` is a helper function we inherit from the parent class to fill in the args with defaults. Which brings
+us to:
 
 ```php
-/**
- * Class Button
- *
- * @property string   $type
- * @property string   $aria_label
- * @property string[] $classes
- * @property string[] $attrs
- * @property string   $content
- */
+protected function defaults(): array {
+    return [
+        self::CLASSES    => [],
+        self::ATTRS      => [],
+        self::TYPE       => '',
+        self::ARIA_LABEL => '',
+        self::CONTENT    => '',
+    ];
+}
 ```
 
-The docblock at the top of the class should mirror the `$properties` below it. The docblock itself doesn't provide any
-functionality to the application, but it does give your IDE autocompletion of some magic properties when it's working
-with an instance of the Context. Each of the `$properties` that we declare can also be accessed using the
-`__get()` and `__set()` magic methods. E.g.:
+Use the `defaults()` method to configure those default values. Often we'll just want propertly typed empty values,
+but sometimes we'll have other reasonable defaults. 
 
 ```php
-$the_aria_label = $button_context->aria_label; // get a value from the Button Context object
-$button_context->aria_label = 'new label'; // set new values on the Button Context object
-``` 
+protected function required(): array {
+    return [
+      self::CLASSES => [ 'this-is-a-button' ],
+    ];
+}
+```
+
+Anything returned in the `defaults()` array may be overridden by arguments passed into the component. To ensure that
+certain values always exists, add them in the `required()` array. These will be merged with the passed arguments.
+Note that this only works with arguments that are arrays to begin with. If you're setting a required value for a scalar
+argument, it shouldn't be an argument in the first place.
+
+The rest of the class consists of various `get_*` and `has_*` public methods. These comprise the public API of the
+controller that will be used by the template.
+
+Some of this will just returning the value of an existing property.
 
 ```php
-public function get_data(): array {
+public function get_content(): string {
+    return $this->content;
+}
+```
+
+Others may massage that data a little bit, for example sanitizing and merging classes into a class string.
+
+```php
+public function get_classes(): string {
+    return Markup_Utils::class_attribute( $this->classes );
+}
+```
+
+Others may combine multiple properties to produce a single value, as we do here with the attributes.
+
+```php
+public function get_attrs(): string {
+    $attributes = $this->attrs;
+
     if ( $this->type ) {
-        $this->properties[ self::ATTRS ][ self::VALUE ]['type'] = $this->type;
+        $attributes['type'] = $this->type;
     }
 
     if ( $this->aria_label ) {
-        $this->properties[ self::ATTRS ][ self::VALUE ]['aria-label'] = $this->aria_label;
+        $attributes['aria-label'] = $this->aria_label;
     }
 
-    return parent::get_data();
+    return Markup_Utils::concat_attrs( $attributes );
 }
 ```
-
-You won't see the `get_data()` method in all `Context` subclasses. Many of them will simply pass there data through
-to their corresponding template. But if some logic needs to run to massage that data before it is rendered, this is
-the place to make it happen. In our example, we're merging the `type` and `aria-label` parameters into the `attrs`
-parameter so that they will all be rendered as a single attributes string (due to the `self::MERGE_ATTRIBUTES`
-declaration on the `attrs` property).
-
-*VERY IMPORTANT NOTE*: The `get_data()` method should work with the data that was given to the Context. This is not
-the time to query the WordPress database. This is not the time to make an API call. This is not the time to call
-`get_post()` or `is_single()` or anything else that reaches outside of the data we have available to us inside this
-instance. A Context is responsible for structuring the data it has so that it is usable by the template. All of the
-data should be given to it from a Controller when it is instantiated.
-
-## Controllers
-
-Our template echoes variables that are passed to it from the Context. Our Context structures those variables from
-the data it was instantiated with. But where does that data come from in the first place? How do we know what data to
-use? Why are we even rendering a Button?
-
-All of the business logic, all of the database queries, all of the decisions about which components to render occur
-in the Controller.
-
-Imagine, if you will, a post type archive. This archive should display a dozen posts dressed up in little boxes so
-they look like a grid of cards. Each of those cards will have an image, a title, an excerpt, and a "Read More" button.
-How do we use Controllers to build this page using our components? Let's start at the outside and work our way down
-to our button.
-
-When WordPress loads the page, it's going to follow the [Template Hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/)
-and load `archive.php`. There's not going to be much in this file, but it's the gateway to bigger things.
-
-```php
-echo tribe_template( \Tribe\Project\Templates\Controllers\Page\Index::class );
-```
-
-The function `tribe_template()` is responsible for finding the Controller we've asked for (`Index`, in this example)
-and giving us an instance from the [DI container](./container.md). Like many Controllers, `Index` requires several
-other controllers to help it complete its job of rendering our archive page. All of these other Controllers are
-listed in `Index`'s constructor.
-
-```php
-public function __construct(
-    Tribe\Project\Templates\Component_Factory $factory,
-    Tribe\Project\Templates\Controllers\Document\Document $document,
-    Tribe\Project\Templates\Controllers\Header\Subheader $header,
-    Tribe\Project\Templates\Controllers\Content\Loop_Item $item
-) {
-    parent::__construct( $factory );
-    $this->document = $document;
-    $this->header   = $header;
-    $this->item     = $item;
-}
-```
-
-Thanks to the magic of DI autowiring, we don't have to worry too much about how to create these other Controllers, or
-the Controllers they might depend on, or the Controllers they might depend on, etc. The container will sort all of that
-out to give us the instances we need.
-
-The `Index` Controller will uses these other Controllers to build up the parameters it will pass to its own Context
-(probably the `Page\Index` Context), which, among other things, expects an array of rendered posts. This array will
-be built using the `Loop_Item` Controller.
-
-```php
-protected function render_posts(): array {
-    $posts = [];
-    while ( have_posts() ) {
-        the_post();
-        $posts[] = $this->item->render();
-    }
-    rewind_posts();
-
-    return $posts;
-}
-```
-
-Look at that! It's the [WordPress Loop](https://developer.wordpress.org/themes/basics/the-loop/)! Our `Index`
-Controller handles the logic of looping through The Loop, but then asks the `Loop_Item` Controller to render each post
-in the global context set up by `the_post()`.
-
-Moving down into the `Loop_Item` Controller, it's time to gather the data that we're going to send to our `Card`
-Context that we want to use to render the post. We mentioned needing an image, a title, an excerpt, and a button.
-
-Let's start with the title, because it's simple. For our title, we might use a `Text` component, because it's made of
-text. In our Controller, we can get that value using normal WordPress functions. Remember that the global `$post` was
-already set up in the `Index` Controller when it called `the_post()` in The Loop.
-
-```php
-$title = get_the_title();
-```
-
-All of our Controllers have a `Component_Factory` available to them that helps us instantiate our components.
-
-```php
-$title = $this->factory->get( Text::class, [
-  Text::TEXT    => get_the_title(),
-  Text::TAG     => 'h2',
-  Text::CLASSES => [ 'item-title' ],
-] )->render();
-```
-
-With this, we've rendered our title in an `<h2>` tag. Something like:
-
-```html
-<h2 class="item-title">LEGO Millennium Falcon Teardown</h2>
-```
-
-We would probably do something similar with the excerpt.
-
-The `Image` component is a special beast that we should address. Remember earlier, when we said that a Context should
-only work with the data given to it and should not make database queries. That's still true. So we're going to need
-to give the `Image` component all of the data it needs to render an image. We have a special helper class for just this
-purpose, called `\Tribe\Project\Templates\Models\Image`. Its static `factory()` method will help us transform an
-attachment ID into an object the `Image` component can use, containing all of te data it might need for the image.
-
-```php
-$image = $this->facotry->get( Image::class, [
-  Image::ATTACHMENT => Models\Image::factory( get_post_thumbnail_id() ),
-  Image::SRC_SIZE   => Image_Sizes::COMPONENT_CARD,
-  // and sooooo many more args we might use here
-] )->render();
-```
-
-Finally, let's look at our button. Really, it's a link that looks like a button. Its markup will look something like:
-
-```html
-<a class="button-link read-more" aria-label="Read more about LEGO Millennium Falcon Teardown">Read More</a>
-```
-
-```php
-$button = $this->factory->get( Link::class, [
-  Link::URL        => get_the_permalink(),
-  Link::CLASSES    => [ 'read-more', 'button-link' ],
-  Link::ARIA_LABEL => sprintf( __( 'Read more about %s', 'tribe' ), get_the_title() ),
-  Link::CONTENT    => __( 'Read More', 'tribe' ),
-] )->render();
-```
-
-Similar composition of Components will take place in a variety of Controllers up and down the page hierarchy.
-
-We should note that the Controller is not, strictly speaking, part of a Component. You will notice that the Controller
-does not live in the theme's `components` directory with all of the other pieces of the Component. Sometimes we have
-a 1-to-1 relationship between a Controller and the Component that it uses to render its data; sometimes a Controller
-will compose several Components together.
-
-Here is the distinction we make: Controllers manage application logic; logic belongs in the Core plugin. Components
-render data; rendering belongs in the Core theme. Even though Controllers and Components are intimately intertwined,
-they live in separate worlds.
-
-A Component could be copied from one project to another, and it would give the same output for the same input,
-regardless of its environment. Controllers must be handled with more delicacy, due to their entanglements with
-application-specific logic.
 
 ## CSS
 
-We could stop here and have a fully functional Component, instantiated and rendered by a Controller. But wait,
-there's more! Component styles live right next to the Template and the Context inside the Component's directory.
-It starts with `index.pcss`. This is a clearing-house to load additional files found in the Component's `css`
-subdirectory. The build system will find this `index.pcss` and load it (along with any files it imports) into the
-global CSS bundle.
+We could stop here and have a fully functional Component. But wait, there's more! Component styles live right next to
+the Template and the Controller inside the Component's directory. It starts with `index.pcss`. This is a clearing
+-house to load additional files found in the Component's `css` subdirectory. The build system will find this
+`index.pcss` and load it (along with any files it imports) into the global CSS bundle.
 
 ## JavaScript
 
 And let's not stop with just styles. We can have portable, component-specific behaviors encapsulated in JavaScript
 files that live right along side the Template. Create an `index.js` file to serve as a clearing-house, loading
-additional files found in the Component's `js` directory. Teh build system will find this `index.js` and load it
+additional files found in the Component's `js` directory. The build system will find this `index.js` and load it
 (along with anything it imports) into the global JS bundle.
+
+## Loading the Component
+
+Let's jump back up to the HTML output we want to render for our button:
+
+```html
+<button type="button" class="close-button" aria-label="Close">
+	<span class="icon-close"></span>Close
+</button>
+```
+
+We have all the code in our template and our controller to render this, but how do we include it from another template?
+For this, we rely on WordPress's `get_template_part()` function. We give it the path to the component we want and the
+arguments that we want to pass into the component.
+
+```php
+get_template_part( 'components/button/button', null, [
+  Button_Controller::TYPE       => 'button',
+  Button_Controller::CLASSES    => [ 'close-button' ],
+  Button_Controller::ARIA_LABEL => __( 'Close', 'tribe' ),
+  Button_Controller::CONTENT    => sprintf( '<span class="icon-close"></span>%s', __( 'Close', 'tribe' ) ),
+] );
+```
+
+This will echo the rendered component to the browser. If you need to save the output to a variable instead of
+echoing, use `tribe_template_part()`. Calling `echo tribe_template_part()` is exactly the same as calling
+`get_template_part()`.
+
+## Injecting Components into Other Components
+
+Sometimes we have a component where we're passing in arbitrary content. This content might, as in our example above, be
+a simple text string. Or maybe we're passing a full block into a slide, or we're putting a wrapper each link in a list.
+
+One approach is to render the component using `tribe_template_part()`, and then pass the rendered string into its
+wrapper. This is often the correct solution, but occasionally it removes some of the flexibility we need.
+
+For these rare cases, we offer `defer_template_part()`. It's used just like `tribe_template_part()`, but instead of a
+string, it will return a `Deferred_Component` object. Think of this object as analogous to Schrödinger's cat. It is
+a fully rendered component, while at the same time being a flexible object that we can continue to manipulate. We can
+continue to read and set arguments to the template's controller, e.g., to add class names or attributes, change
+header levels, etc. Only when we finally force that `Deferred_Component` object to become a string, either
+explicitly (`(string) $content`) or implicitly (`echo $content`), does it collapse into its final observable state.
+
+Right now, you're thinking that sounds overly complicated. You're absolutely correct; 99% of the time, this is
+unnecessary abstraction. For that other 1%, we'll be happy to have it around. Here's a contrived example of how we
+might use it:
+
+I have a list of links. Each of those will be rendered with a `Link` component. Each of those links is going to have
+an `<li>` wrapper around it. And I'm going to pass that list of wrapped links into a widget. Depending on where that
+widget displays on the site (e.g., in the sidebar or the footer), I might need different classes on those `<li>`
+wrappers so they can be styled appropriately.
+
+```php
+// this will all probably be in a controller somewhere
+$link_data = some_function_that_gives_me_my_link_data();
+
+$link_components = array_map( static function( $data ) {
+  return defer_template_part( 'components/link/link', null, [
+    Link_Controller::URL     => $data['url'],
+    Link_Controller::CONTENT => $data['label'],
+  ] );
+}, $link_data );
+
+$wrapped_components = array_map( static function( $link ) {
+  return defer_template_part( 'components/container/container', null, [
+    Container_Controller::TAG     => 'li',
+    Container_Controller::CONTENT => $link,
+  ] );
+}, $link_components );
+
+// footer_widgets.php
+get_template_part( 'components/link_list_widget/link_list_widget', null, [
+  Link_List_Widget_Controller::LINKS   => $wrapped_components,
+  Link_List_Widget_Controller::CONTEXT => 'footer',
+] );
+
+// Link_List_Widget_Controller.php
+class Link_List_Widget_Controller extends Abstract_Controller {
+  // ... skipping over a lot here
+  public function get_links(): iterable {
+    foreach ( $this->links as $link ) {
+      // add a contextual class to the wrapper
+      $link['classes'][] = sprintf( '%s-widget-link', $this->context );
+      yield $link;
+    }
+  }
+}
+
+// link_list_widget.php
+?>
+<ul>
+<?php foreach ( $c->get_links() as $link ) {
+  // the Deferred_Component is finally cast to a string here, causing the container and its nested link to render
+  echo $link;
+} ?>
+</ul>
+```
 
 ## So. Much. Typing.
 
@@ -465,7 +430,7 @@ is a decent amount of work for essentially the exact same result as, say, just u
 sprinkled in. 
 
 However, the amount of power and flexibility this gives us is, in my humble opinion, _well_ worth the learning curve.
-For one, if you ever need to update the markup for Buttons across the site, you update a _single Twig file_ and it
+For one, if you ever need to update the markup for Buttons across the site, you update a _single template file_ and it
 flows throughout the entire site! Need to slightly modify the markup structure? Make one change, and BOOM it’s all
 over your site. Need to make your Title components to all have aria labels? Make that change once, and you have it
 for every single Title Component. 
@@ -475,7 +440,7 @@ display file.
 
 For instance, what if you Text component needs to do a call to an API to get the content? That requires multiple
 methods for making the curl request, caching results, invalidating the cache, parsing the data, doing sanitization,
-etc. Now that can all live in the Controller calling the Text component, and the Text component itself can remain
+etc. Now that can all live in a dependency calling the Text component, and the Text component itself can remain
 clean and simple. Separation of concerns is always a good route, and this architecture allows that.
 
 But still…that's a lot of typing. We're developers, aren't we? What do we do with time-consuming, tedious tasks?
@@ -484,23 +449,23 @@ We automate them! Let's take a look at the component generator.
 That's right. We wrote code to write our code. Next week we're working on writing a generator generator.
 
 ```
-wp s1 generate component link --properties=url,target,aria_label,content --css --js --controller
+wp s1 generate component link
 ```
 
 This command from the [`moderntribe/square1-generators` package from Tribe Libs](https://github.com/moderntribe/square1-generators)
-will create all of the files you need to get started with a new component, populating it with all of the properties
-you asked for. Even better than copying/pasting chunks of code from one component to another, the generator will
-ensure you have all the pieces you need, consistently following the SquareOne patterns.
+will create all of the files you need to get started with a new component. Even better than copying/pasting chunks of
+code from one component to another, the generator will ensure you have all the pieces you need, consistently
+following the SquareOne patterns.
 
 ## Workflows
 I’ve seen a lot of conversation around the correct workflow for using Components. Since they use both Controllers
-(BE Dev!) and Twig Files (FE Dev!), who needs to do the work first? On the one hand, this can be a bit of a
+(BE Dev!) and template Files (FE Dev!), who needs to do the work first? On the one hand, this can be a bit of a
 chicken-egg scenario. On the other hand, since we’re completely separating the logic from the template, it also
 sort of doesn’t matter! 
 
 If the FE dev gets to it first, they can just make a static template with some test values and let the BE dev work out
 the Controllers to make that a reality. Or, if they’re comfortable in PHP, they can simply add static values to the
-`$properties` array in the Context and let BE hop in later to update it with actual dynamic content. 
+properties in the Controller and let BE hop in later to update it with actual dynamic content. 
 
 If BE gets to it first, they can simply follow the Data Architecture and set up the various components. Then FE can
 make any tweaks they want to the existing setup and style the results. 
@@ -513,7 +478,7 @@ making sure the process goes smoothly.
 The entire philosophy behind Components is to provide an architecture that speeds up development and makes our work
 more consistent and maintainable. However, they’re also not a one-size-fits-every-single-context solution. Sometimes,
 a block really does need to have custom markup. If you ever find yourself (BE _or_ FE) struggling to shoehorn a design
-into components, make a new one! Components should work for you, not the other way  around. And if the new component
+into components, make a new one! Components should work for you, not the other way around. And if the new component
 you made seems useful as a core SquareOne component, submit a PR! We’re always looking to improve this system. 
 
 Now, on the other hand, if you find yourself creating a lot of custom components, it might be time for some reflection

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -61,7 +61,7 @@ salient details. Here's the HTML we want to generate from a Button component:
 
 ## HTML Templates
 
-Our Button component's directory will contain a PHP file named `button.twig`. It will look like:
+Our Button component's directory will contain a PHP file named `button.php`. It will look like:
 
 ```php
 <?php


### PR DESCRIPTION
## What does this do/fix?

Rewrites the component docs to match our new templating paradigm. No more references to Twig or Contexts. Explains how to use `get_template_part()` and our related wrappers.

I'm sure there's more to add to this, but it's a start.

## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because...it is documentation.
- [ ] No, I need help figuring out how to write the tests.

