### PR TITLE
Update .editorconfig pcss rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,8 +26,8 @@ spaces_within_imports = true
 indent_style = space
 indent_size = 2
 
-# Indentation override for all CSS under pcss directory
-[wp-content/themes/core/pcss/**/**/*.pcss]
+# Indentation override for all CSS under theme directory
+[wp-content/themes/core/**/**/*.pcss]
 indent_style = tab
 
 [*.json]


### PR DESCRIPTION
The previously defined glob for .pcss files did not resolve properly the editor would not apply editor config settings.

## What does this do/fix?

Updates the glob for `.pcss` files.


## QA

Links to relevant issues
- [Link to Issue](https://example.com)

Links to deployed, scaffolded demo:
- [Link to Demo](https://example.com)

Screenshots/video:
- [Link to Video](https://example.com)

## Tests

Does this have tests?

- [x] Yes
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

- Open your editor and verify that `.pcss` files use tabs instead of spaces when auto-formatted.