### PR TITLE
Update .editorconfig js rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,8 +16,8 @@ indent_size = 2
 [*.md]
 trim_trailing_whitespace = false
 
-# Indentation override for all JS under assets directory
-[wp-content/themes/core/assets/js/src/**/*.js]
+# Indentation override for all JS under theme directory
+[wp-content/themes/core/**/*.js]
 indent_style = tab
 spaces_within_imports = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,8 +16,8 @@ indent_size = 2
 [*.md]
 trim_trailing_whitespace = false
 
-# Indentation override for all JS under lib directory
-[wp-content/themes/core/js/src/**/*.js]
+# Indentation override for all JS under assets directory
+[wp-content/themes/core/assets/js/src/**/*.js]
 indent_style = tab
 spaces_within_imports = true
 


### PR DESCRIPTION
## What does this do/fix?

The previously defined glob for .js files did not resolve properly so the editor would not apply editor config settings.

## Tests

Does this have tests?

- [x] Yes: Open your editor and verify that .js files use tabs instead of spaces when auto-formatted.
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

