### PR TITLE
Add correct image width & height attributes for SVG images.

### DIFF
--- a/wp-content/plugins/core/src/Theme/Media/SVG_Filters.php
+++ b/wp-content/plugins/core/src/Theme/Media/SVG_Filters.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tribe\Project\Theme\Media;
+
+class SVG_Filters {
+	/**
+	 * Filters the image src result.
+	 *
+	 * The Safe SVG plugin sets the width & height attributes to false.
+	 * This causes our FE srcset values to be invalid for lazysizes.
+	 *
+	 * WordPress saves the correct SVG image dimensions in the image's full-size attributes.
+	 * We're going to use the full-size values and set the correct values based on the
+	 * requested size's aspect ratio.
+	 *
+	 * Note: This code will ALWAYS scale (not crop) the SVG to fit the requested size.
+	 * If your use-case requires cropping SVG images, then this filter should be disabled.
+	 *
+	 * @param array|false  $image         Either array with src, width & height, icon src, or false.
+	 * @param int          $attachment_id Image attachment ID.
+	 * @param string|array $size          Size of image. Image size or array of width and height values (in that
+	 *                                    order). Default 'thumbnail'.
+	 * @param bool         $icon          Whether the image should be treated as an icon. Default false.
+	 *
+	 * @return array
+	 * @filter wp_get_attachment_image_src
+	 */
+	public function set_accurate_sizes( $image, $attachment_id, $size, $icon ) {
+		if ( get_post_mime_type( $attachment_id ) !== 'image/svg+xml' ) {
+			return $image;
+		}
+
+		$meta = wp_get_attachment_metadata( $attachment_id );
+
+		if ( is_array( $size ) ) {
+			// If a specific width & height are requested, just use them
+			$requested_size['width']  = $size[0];
+			$requested_size['height'] = $size[1];
+		} else {
+			// Otherwise check for the requested size key in the available sizes.
+			$requested_size = isset( $meta[ 'sizes' ][ $size ] ) ? $meta[ 'sizes' ][ $size ] : false;
+
+			if ( ! $requested_size ) {
+				return $image;
+			}
+		}
+
+		// Width
+		$image[1] = intval( $requested_size['width'] );
+
+		// Height
+		$image[2] = intval( $requested_size['width'] * $meta['height'] / $meta['width'] );
+
+		return $image;
+	}
+}

--- a/wp-content/plugins/core/src/Theme/Media/SVG_Filters.php
+++ b/wp-content/plugins/core/src/Theme/Media/SVG_Filters.php
@@ -30,6 +30,11 @@ class SVG_Filters {
 			return $image;
 		}
 
+		// Don't process images existing size with values
+		if ( $image[1] !== false && $image[2] !== false ) {
+			return $image;
+		}
+
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
 		if ( is_array( $size ) ) {

--- a/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
+++ b/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
@@ -12,6 +12,7 @@ use Tribe\Project\Theme\Config\Supports;
 use Tribe\Project\Theme\Config\Web_Fonts;
 use Tribe\Project\Theme\Media\Image_Wrap;
 use Tribe\Project\Theme\Media\Oembed_Filter;
+use Tribe\Project\Theme\Media\SVG_Filters;
 
 class Theme_Subscriber extends Abstract_Subscriber {
 	public function register(): void {
@@ -37,6 +38,7 @@ class Theme_Subscriber extends Abstract_Subscriber {
 		$this->image_wrap();
 		$this->image_links();
 		$this->oembed();
+		$this->svgs();
 	}
 
 	private function body_classes() {
@@ -104,6 +106,12 @@ class Theme_Subscriber extends Abstract_Subscriber {
 		add_filter( 'embed_oembed_html', function ( $html, $url, $attr, $post_id ) {
 			return $this->container->get( Oembed_Filter::class )->wrap_admin_oembed( $html, $url, $attr, $post_id );
 		}, 99, 4 );
+	}
+
+	private function svgs() {
+		add_filter( 'wp_get_attachment_image_src', function ( $image, $attachment_id, $size, $icon ) {
+			return $this->container->get( SVG_Filters::class )->set_accurate_sizes( $image, $attachment_id, $size, $icon );
+		}, 11, 4 );
 	}
 
 	private function supports() {


### PR DESCRIPTION
## What does this do/fix?
The Safe SVG plugin sets the width & height attributes for SVG images to false. Our image lazy-loading library complaints about this with console errors. This PR re-filters the attributes for SVG images to set a valid width & height value based on the requested size and the image's original width & height values.

Of note: this code won't play well if the SVG is supposed to be cropped (like other image formats) for a particular size request. Instead, all size requests are scaled (with aspect ratio integrity). This is fine any SVG usage I can think of, but MMV.

## Tests
Does this have tests?
- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

