### PR TITLE
adds ability to remove core block styles

### DIFF
--- a/wp-content/themes/core/assets/js/src/admin/core/block-styles.js
+++ b/wp-content/themes/core/assets/js/src/admin/core/block-styles.js
@@ -1,0 +1,13 @@
+/**
+ * @function unregisterStyles
+ * @description Unregisters core block styles added client-side. Styles added
+ * 				server-side using register_block_style should be unregistered
+ * 				using the server-side unregister_block_styles function.
+ */
+
+
+const unregisterStyles = () => {
+	wp.blocks.unregisterBlockStyle( 'core/image', [ 'rounded', 'default' ] );
+};
+
+export default unregisterStyles;

--- a/wp-content/themes/core/assets/js/src/admin/core/ready.js
+++ b/wp-content/themes/core/assets/js/src/admin/core/ready.js
@@ -13,6 +13,7 @@ import resize from './resize';
 import plugins from './plugins';
 import viewportDims from './viewport-dims';
 import editor from '../editor';
+import blockStyles from './block-styles';
 
 import { on, ready } from 'utils/events';
 
@@ -46,6 +47,9 @@ const init = () => {
 	// initialize the main scripts
 
 	editor();
+
+	// removes core block styles as needed
+	blockStyles();
 
 	console.info( 'SquareOne Admin: Initialized all javascript that targeted document ready.' );
 };


### PR DESCRIPTION
## What does this do/fix?

Adds a consistent location to remove the core block styles that are registered client-side since they [cannot be removed](https://developer.wordpress.org/block-editor/developers/filters/block-filters/#unregister_block_style) using the server-side `unregister_block_style` function.


## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [X] No, I need help figuring out how to write the tests.

