### PR TITLE
Fix cache docs typo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2020.10
+* Fixed: Typo in object-cache docs. 
+
+
 ## 2020.09
 * Updated: Various codebase configs.
     * local-config-sample.php: cleaned up no longer needed items

--- a/docs/concepts/object-cache.md
+++ b/docs/concepts/object-cache.md
@@ -33,7 +33,7 @@ The `Cache` object provides a wrapper around WordPress's object caching to suppo
 keys and the invalidation of entire cache groups.
 
 * `$cache->set( $key, $value, $group, $expiration )` - sets a value in the cache
-* `$cache->get( $key, $value )` - retrieves the value
+* `$cache->get( $key, $group )` - retrieves the value
 * `$cache->delete( $key, $group )` - deletes the value
 
 The `$key` argument may be any serializable value, including arrays and objects.


### PR DESCRIPTION
## What does this do/fix?

Fixes typo in object-cache docs.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

