### PR TITLE
Feature/core plugin updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     "humanmade/mercator": "dev-master#7f3846a",
     "humanmade/s3-uploads": "2.2.1",
     "johnbillion/extended-cpts": "^4.0",
-    "johnpbloch/wordpress-core": "5.5.1",
+    "johnpbloch/wordpress-core": "5.5.3",
     "johnpbloch/wordpress-core-installer": "1.0.0",
     "mailgun/mailgun-php": "^2.8",
     "moderntribe/acf-image-select": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
       "type": "package",
       "package": {
         "name": "advanced-custom-fields/advanced-custom-fields-pro",
-        "version": "5.9.0",
+        "version": "5.9.3",
         "type": "wordpress-plugin",
         "dist": {
           "type": "zip",
@@ -94,14 +94,14 @@
     "wpackagist-plugin/configure-smtp": "3.1",
     "wpackagist-plugin/disable-emojis": "1.7.2",
     "wpackagist-plugin/gravity-forms-wcag-20-form-fields": "1.7.2",
-    "wpackagist-plugin/limit-login-attempts-reloaded": "2.15.1",
+    "wpackagist-plugin/limit-login-attempts-reloaded": "2.15.2",
     "wpackagist-plugin/posts-to-posts": "1.6.6",
-    "wpackagist-plugin/redirection": "4.8",
-    "wpackagist-plugin/regenerate-thumbnails": "3.1.3",
+    "wpackagist-plugin/redirection": "4.9.2",
+    "wpackagist-plugin/regenerate-thumbnails": "3.1.4",
     "wpackagist-plugin/safe-svg": "1.9.9",
-    "wpackagist-plugin/the-events-calendar": "5.1.6",
-    "wpackagist-plugin/user-switching": "1.5.5",
-    "wpackagist-plugin/wordpress-seo": "14.9",
+    "wpackagist-plugin/the-events-calendar": "5.2.1",
+    "wpackagist-plugin/user-switching": "1.5.6",
+    "wpackagist-plugin/wordpress-seo": "15.2.1",
     "wpackagist-plugin/wp-tota11y": "^1.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,14 +4,14 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6567f6cc5992eddb0cd42dded030efae",
+    "content-hash": "29f0bcb539dcae2b8c7cdaf67d200e48",
     "packages": [
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
-            "version": "5.9.0",
+            "version": "5.9.3",
             "dist": {
                 "type": "zip",
-                "url": "https://connect.advancedcustomfields.com/index.php?a=download&p=pro&k={%WP_PLUGIN_ACF_KEY}&t=5.9.0"
+                "url": "https://connect.advancedcustomfields.com/index.php?a=download&p=pro&k={%WP_PLUGIN_ACF_KEY}&t=5.9.3"
             },
             "require": {
                 "ffraenz/private-composer-installer": "^3.0"
@@ -3105,15 +3105,15 @@
         },
         {
             "name": "wpackagist-plugin/limit-login-attempts-reloaded",
-            "version": "2.15.1",
+            "version": "2.15.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/limit-login-attempts-reloaded/",
-                "reference": "tags/2.15.1"
+                "reference": "tags/2.15.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/limit-login-attempts-reloaded.2.15.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/limit-login-attempts-reloaded.2.15.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -3141,15 +3141,15 @@
         },
         {
             "name": "wpackagist-plugin/redirection",
-            "version": "4.8",
+            "version": "4.9.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/redirection/",
-                "reference": "tags/4.8"
+                "reference": "tags/4.9.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/redirection.4.8.zip"
+                "url": "https://downloads.wordpress.org/plugin/redirection.4.9.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -3159,15 +3159,15 @@
         },
         {
             "name": "wpackagist-plugin/regenerate-thumbnails",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/regenerate-thumbnails/",
-                "reference": "tags/3.1.3"
+                "reference": "tags/3.1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/regenerate-thumbnails.3.1.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/regenerate-thumbnails.3.1.4.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -3195,15 +3195,15 @@
         },
         {
             "name": "wpackagist-plugin/the-events-calendar",
-            "version": "5.1.6",
+            "version": "5.2.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/the-events-calendar/",
-                "reference": "tags/5.1.6"
+                "reference": "tags/5.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/the-events-calendar.5.1.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/the-events-calendar.5.2.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -3213,15 +3213,15 @@
         },
         {
             "name": "wpackagist-plugin/user-switching",
-            "version": "1.5.5",
+            "version": "1.5.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/user-switching/",
-                "reference": "tags/1.5.5"
+                "reference": "tags/1.5.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/user-switching.1.5.5.zip"
+                "url": "https://downloads.wordpress.org/plugin/user-switching.1.5.6.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -3231,15 +3231,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "14.9",
+            "version": "15.2.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/14.9"
+                "reference": "tags/15.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.14.9.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.15.2.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b0e94d2c704955b1b8aa7a13b6475c5",
+    "content-hash": "6567f6cc5992eddb0cd42dded030efae",
     "packages": [
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
@@ -809,16 +809,16 @@
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.5.1",
+            "version": "5.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "fa5bcb1579eae33baef6c04355f8d6657e5bd349"
+                "reference": "6f25ae53f3d4058f8dd702c097d5a4a45667af61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/fa5bcb1579eae33baef6c04355f8d6657e5bd349",
-                "reference": "fa5bcb1579eae33baef6c04355f8d6657e5bd349",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/6f25ae53f3d4058f8dd702c097d5a4a45667af61",
+                "reference": "6f25ae53f3d4058f8dd702c097d5a4a45667af61",
                 "shasum": ""
             },
             "require": {
@@ -826,7 +826,7 @@
                 "php": ">=5.6.20"
             },
             "provide": {
-                "wordpress/core-implementation": "5.5.1"
+                "wordpress/core-implementation": "5.5.3"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -846,7 +846,7 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2020-09-01T19:07:35+00:00"
+            "time": "2020-10-30T20:48:12+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",


### PR DESCRIPTION
## What does this do/fix?

Updates WP to 5.5.3
Updates various plugins:

```
limit-login-attempts-reloaded (2.15.1 => 2.15.2)
redirection (4.8 => 4.9.2)
regenerate-thumbnails (3.1.3 => 3.1.4)
the-events-calendar (5.1.6 => 5.2.1)
user-switching (1.5.5 => 1.5.6)
wordpress-seo (14.9 => 15.2.1)
advanced-custom-fields-pro (5.9.0 => 5.9.3)  
```
