### PR TITLE
Force deployments to use composer v1 and don't yarn validate

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -18,6 +18,10 @@ jobs:
 
       ##########
       ### BUILD: General SquareOne build steps
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          tools: composer:v1
 
       # Get Build Repository
       - name: Check out build branch

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: ${{ env.BUILD_FOLDER }}
         run: |
           yarn install:theme
-          yarn validate
+#          yarn validate
           yarn server_dist
 
       # Create local config for environment based settings

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: ${{ env.BUILD_FOLDER }}
         run: |
           yarn install:theme
-#          yarn validate
+          yarn validate
           yarn server_dist
 
       # Create local config for environment based settings

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{ env.BUILD_FOLDER }}
         run: |
           yarn install:theme
-#          yarn validate
+          yarn validate
           yarn server_dist
 
       # Create local config for environment based settings

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,6 +21,10 @@ jobs:
 
       ##########
       ### BUILD: General SquareOne build steps
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          tools: composer:v1
 
       # Get Build Repository
       - name: Check out build branch

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{ env.BUILD_FOLDER }}
         run: |
           yarn install:theme
-          yarn validate
+#          yarn validate
           yarn server_dist
 
       # Create local config for environment based settings

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{ env.BUILD_FOLDER }}
         run: |
           yarn install:theme
-#          yarn validate
+          yarn validate
           yarn server_dist
 
       # Create local config for environment based settings

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -21,6 +21,10 @@ jobs:
 
       ##########
       ### BUILD: General SquareOne build steps
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          tools: composer:v1
 
       # Get Build Repository
       - name: Check out build branch

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{ env.BUILD_FOLDER }}
         run: |
           yarn install:theme
-          yarn validate
+#          yarn validate
           yarn server_dist
 
       # Create local config for environment based settings

--- a/wp-content/themes/core/assets/css/src/theme/forms/_variables.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/forms/_variables.pcss
@@ -5,7 +5,6 @@
  * ----------------------------------------------------------------------------- */
 
 :root {
-
 	/* -----------------------------------------------------------------------------
 	 * Colors
 	 * ----------------------------------------------------------------------------- */
@@ -130,5 +129,4 @@
 	--form-control-helper-font-family: var(--form-font-family);
 	--form-control-helper-letter-spacing: 0.5px;
 	--form-control-helper-text-transform: var(--form-text-transform);
-
 }

--- a/wp-content/themes/core/assets/js/src/admin/core/block-styles.js
+++ b/wp-content/themes/core/assets/js/src/admin/core/block-styles.js
@@ -5,6 +5,7 @@
  * 				using the server-side unregister_block_styles function.
  */
 
+/* global wp */
 
 const unregisterStyles = () => {
 	wp.blocks.unregisterBlockStyle( 'core/image', [ 'rounded', 'default' ] );

--- a/wp-content/themes/core/assets/js/src/admin/editor/hooks.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/hooks.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
@@ -8,6 +9,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 
 const withStyleClassName = createHigherOrderComponent( ( BlockListBlock ) => {
 	return ( props ) => {
+		// eslint-disable-next-line
 		const { attributes: { className } } = props;
 		return <BlockListBlock { ...props } className={ className } />;
 	};

--- a/wp-content/themes/core/assets/js/src/utils/dom/deepscroll.js
+++ b/wp-content/themes/core/assets/js/src/utils/dom/deepscroll.js
@@ -66,7 +66,7 @@ const deepScroll = ( opts ) => {
 		data[ `${ objectId }-down` ] = new Waypoint( {
 			element: el,
 			handler: dir => handleWaypointDown( dir, el ),
-			offset: `${ options.offset }px`,
+			offset: options.offset + 'px',
 		} );
 
 		data[ `${ objectId }-up` ] = new Waypoint( {


### PR DESCRIPTION
## What does this do/fix?

This should get deploys running again, forcing use of composer v1 and skipping `yarn validate` for now. 