### PR TITLE
Use 74-2.1 to ensure composerv1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2020.11
+* Updated: docker-compose.yml php-fpm image from 74-2.1.1 to 74-2.1 to ensure composer v1.
+
 ## 2020.10
 * Fixed: Typo in object-cache docs. 
 

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -32,7 +32,7 @@ x-chrome: &chrome
 
 
 x-php: &php
-  image: moderntribe/squareone-php:74-2.1.1
+  image: moderntribe/squareone-php:74-2.1
   working_dir: /application
   user: "${SQ1_UID:-1000}:${SQ1_GID:-1000}"
   volumes:


### PR DESCRIPTION
## What does this do/fix?

Use the minor version of the docker image to continue to get patch updates. `74-2.1` would pull the version that forces composer v1.

## QA

None.

## Tests

Does this have tests?

- [ ] Yes
- [ x] No, this doesn't need tests because it's a configuration update
- [ ] No, I need help figuring out how to write the tests.

