### PR TITLE
Updates ssh-agent GH action.

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -67,7 +67,7 @@ jobs:
 
       # Setup SSH key for deploy environment
       - name: HOST SCM SSH KEY
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{secrets.DEPLOY_PRIVATE_SSH_KEY}}
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -70,7 +70,7 @@ jobs:
 
       # Setup SSH key for deploy environment
       - name: HOST SCM SSH KEY
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{secrets.DEPLOY_PRIVATE_SSH_KEY}}
 

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -70,7 +70,7 @@ jobs:
 
       # Setup SSH key for deploy environment
       - name: HOST SCM SSH KEY
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{secrets.DEPLOY_PRIVATE_SSH_KEY}}
 


### PR DESCRIPTION
Fixes error with ssh-agent:

`Error: Unable to process command '##[set-env name=SSH_AUTH_SOCK;]/tmp/ssh-auth.sock' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/`