### PR TITLE
Corrects the name for the Classic Block in the allow list.

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -86,7 +86,7 @@ class Blocks_Definer implements Definer_Interface {
 				'core/audio',
 				'core/block',
 				//'core/buttons',
-				'core/classic',
+				'core/freeform',
 				'core/code',
 				'core/embed',
 				'core/file',

--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -85,11 +85,10 @@ class Blocks_Definer implements Definer_Interface {
 				'core-embed/youtube',
 				'core/audio',
 				'core/block',
-				//'core/buttons',
-				'core/freeform',
 				'core/code',
 				'core/embed',
 				'core/file',
+				'core/freeform',
 				'core/gallery',
 				'core/heading',
 				'core/html',
@@ -103,6 +102,7 @@ class Blocks_Definer implements Definer_Interface {
 				'core/table',
 				'core/video',
 				'gravityforms/form',
+				//'core/buttons',
 			],
 
 			/**


### PR DESCRIPTION
## What does this do/fix?

Fixes a typo causing the classic editor block to not be available.  The[ classic block is named](https://github.com/WordPress/gutenberg/tree/master/packages/block-library/src/freeform) `core/freeform`.

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [X] No, I need help figuring out how to write the tests.

