### PR TITLE
remove travis badge for gha badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![./example/example.svg](./logo.svg)
 
-![Build Status](https://github.com/moderntribesquare-one/workflows/.github/workflows/ci.yml/badge.svg?event=pull_request)
+![Codeception Tests](https://github.com/moderntribe/square-one/workflows/Codeception%20Tests/badge.svg)
 
 SquareOne is a development framework lovingly maintained by Modern Tribe used for WordPress projects. It augments WordPress into a modern application framework. We think it's pretty neat.   
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![./example/example.svg](./logo.svg)
 
-![Tests](https://github.com/moderntribe/square-one/workflows/ci/badge.svg)
+![Build Status](https://github.com/moderntribe/square-one/workflows/ci/badge.svg)
 
 SquareOne is a development framework lovingly maintained by Modern Tribe used for WordPress projects. It augments WordPress into a modern application framework. We think it's pretty neat.   
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![./example/example.svg](./logo.svg)
 
-![Build Status](https://github.com/moderntribe/square-one/workflows/ci/badge.svg)
+![Build Status](https://github.com/moderntribesquare-one/workflows/.github/workflows/ci.yml/badge.svg?event=pull_request)
 
 SquareOne is a development framework lovingly maintained by Modern Tribe used for WordPress projects. It augments WordPress into a modern application framework. We think it's pretty neat.   
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![./example/example.svg](./logo.svg)
 
-[![Build Status](https://travis-ci.com/moderntribe/square-one.svg?token=1evq9eFenqSy9NpYbMyT&branch=master)](https://travis-ci.com/moderntribe/square-one)
+![Tests](https://github.com/moderntribe/square-one/workflows/ci/badge.svg)
 
 SquareOne is a development framework lovingly maintained by Modern Tribe used for WordPress projects. It augments WordPress into a modern application framework. We think it's pretty neat.   
 


### PR DESCRIPTION
## What does this do/fix?

Travis tests were failing - because we don't use Travis anymore. Changed the build badge to GHA.

