### PR TITLE
Remove old backend doc links

### DIFF
--- a/wp-content/plugins/core/README.md
+++ b/wp-content/plugins/core/README.md
@@ -12,15 +12,7 @@ Welcome to [1]! The core plugin will be where the majority of back end developme
 * If you have questions about anything at all always ask!
 * Do your best to stick to the conventions and rules laid out in [1], and if you have ideas to improve upon [1] let us know.
 
-**For Complete Back End Documenation View Links Below**
 
-* [Overview](/docs/backend/README.md)
-    * [Container / Core.php](/docs/backend/container.md)
-    * [Custom Post Types](/docs/backend/post-types.md)
-    * [Custom Taxonomies](/docs/backend/taxonomies.md)
-    * [Post & Taxonomy Meta](/docs/backend/post-meta.md)
-    * Plugins/Extensions
-        * [Twig](https://twig.symfony.com/)
-        * [Posts 2 Post](https://github.com/scribu/wp-posts-to-posts/wiki)
-        * [Extended Post Types](https://github.com/johnbillion/extended-cpts/blob/master/README.md)
-        * [Extended Taxonomies](https://github.com/johnbillion/extended-taxos/blob/master/README.md)
+* Plugins/Extensions
+    * [Posts 2 Post](https://github.com/scribu/wp-posts-to-posts/wiki)
+    * [Extended Post Types](https://github.com/johnbillion/extended-cpts/blob/master/README.md)


### PR DESCRIPTION
## What does this do/fix?
Removes links from the Backend Readme that no longer exist. I believe all documentation is now just in the `/docs` folder. I also removed 2 of the plugins that I believe are no longer being used.

## Tests
Does this have tests?
- [ ] Yes
- [X] No, this doesn't need tests because it's just a documentation update.
- [ ] No, I need help figuring out how to write the tests.

