### PR TITLE
Feature/xdebug v3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2021.04
+* Updated: docker php-ini-overrides.ini to use xdebug v3 configuration for latest docker builds.
+
 ## 2021.03
 * Updated: lead form block to use Gravity Forms child / inner block.
 * Updated: updated swiper to latest and addressed slider component issues.

--- a/dev/docker/php/php-ini-overrides.ini
+++ b/dev/docker/php/php-ini-overrides.ini
@@ -4,28 +4,34 @@ log_errors=1
 display_errors=1
 display_startup_errors=1
 error_log=/proc/1/fd/2
-xdebug.cli_color=1
-; force cli to always show errors
-;xdebug.force_display_errors=1
 
 upload_max_filesize=100M
 post_max_size=108M
 
+; xdebug
 xdebug.idekey="PHPSTORM"
+xdebug.mode=debug,profile,trace
+xdebug.start_with_request=trigger
+xdebug.client_host=host.tribe
 
-xdebug.profiler_enable=0
+; xdebug profiling
 xdebug.profiler_append=1
-xdebug.profiler_output_dir=/application/www/wp-content/uploads
-xdebug.profiler_enable_trigger=1
 xdebug.profiler_output_name=cachegrind.out.%H.%R.%t
-
-xdebug.remote_enable=1
-xdebug.remote_host=host.tribe
-xdebug.remote_port=9000
-;xdebug.remote_log=/application/www/wp-content/xdebug.log
+xdebug.output_dir=/application/www/wp-content/uploads
 
 xdebug.var_display_max_children=2048
 xdebug.var_display_max_data=2048
 xdebug.var_display_max_depth=64
+
+xdebug.cli_color=1
+
+; Force cli to always show errors
+;xdebug.force_display_errors=1
+
+; Default debug port is now 9003
+;xdebug.client_port=9000
+
+; Enable logging
+;xdebug.log=/application/www/wp-content/xdebug.log
 
 sendmail_path = /usr/bin/msmtp -t

--- a/dev/docker/php/php-ini-overrides.ini
+++ b/dev/docker/php/php-ini-overrides.ini
@@ -31,7 +31,7 @@ xdebug.cli_color=1
 ; Default debug port is now 9003
 ;xdebug.client_port=9000
 
-; Enable logging
+; Enable xdebug logging
 ;xdebug.log=/application/www/wp-content/xdebug.log
 
 sendmail_path = /usr/bin/msmtp -t


### PR DESCRIPTION
## What does this do/fix?

We need to rebuild our docker images to get the latest composer version in the 1.x branch to support the [new GitHub tokens](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/). All PHP images now come with xdebug version 3.

## Updating your projects

The [new images](https://github.com/moderntribe/squareone-docker-images/pull/8) will roll out shortly on [docker hub](https://hub.docker.com/r/moderntribe/squareone-php/tags?page=1&ordering=last_updated). To bring all projects up to date that are using the `moderntribe/squareone-php` images, the following is recommend:

1. Replace your project's `dev/docker/php/php-ini-overrides.ini` with this one **(make sure you're not overwriting any non-xdebug customizations other devs had made previously)**
1. Ensure your project's `docker-compose.yml` **is not** using the patch version. Correct: `moderntribe/squareone-php:74-2.1` Incorrect: `moderntribe/squareone-php:74-2.1.1`
1. Have your team rebuild their PHP docker images: 
- For php74 projects: `docker pull moderntribe/squareone-php:74-2.1` or the full image + version your project is using if you didn't switch to the patch only version.
- For php73 projects: `docker pull moderntribe/squareone-php:73-1.1`
- For php72 projects: `docker pull moderntribe/squareone-php:72-1.1`

Note that xdebug v3 uses port `9003` instead of 9000 now. PhpStorm automatically adds both ports, but make sure you update your IDE with the correct port.

## Verification

After you've pulled the updated image, start your project with `so start`, then run `so shell` and `php -v` once in the container.
You should see `with Xdebug v3.0.3, Copyright (c) 2002-2021, by Derick Rethans`

## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because this is a configuration change
- [ ] No, I need help figuring out how to write the tests.

