### PR TITLE
Page & Block Color Themes

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
@@ -27,9 +27,12 @@ class Lead_Form extends Block_Config {
 	public const WIDTH_FULL = 'full';
 
 	public const COLOR_THEME         = 'color_theme';
-	public const COLOR_THEME_INHERIT = 'rgba(0,0,0,0)'; // transparent.
-	public const COLOR_THEME_LIGHT   = '#FFF';
-	public const COLOR_THEME_DARK    = '#000';
+	public const COLOR_THEME_CHOICES = [
+		'rgba(0,0,0,0)' => 'Page Theme',
+		'#FFF'          => 'Light',
+		'#000'          => 'Dark',
+	];
+	public const COLOR_THEME_DEFAULT = 'rgba(0,0,0,0)'; // transparent.
 
 	public const FORM_FIELDS  = 'form_fields';
 	public const FORM_STACKED = 'form_stacked';
@@ -123,13 +126,9 @@ class Lead_Form extends Block_Config {
 					'type'            => 'swatch',
 					'name'            => self::COLOR_THEME,
 					'label'           => __( 'Color Theme', 'tribe' ),
-					'choices'         => [
-						self::COLOR_THEME_INHERIT => __( 'Inherit From Page Theme', 'tribe' ),
-						self::COLOR_THEME_LIGHT   => __( 'Light', 'tribe' ),
-						self::COLOR_THEME_DARK    => __( 'Dark', 'tribe' ),
-					],
+					'choices'         => self::COLOR_THEME_CHOICES,
 					'allow_null'      => false,
-					'default_value'   => self::COLOR_THEME_INHERIT,
+					'default_value'   => self::COLOR_THEME_DEFAULT,
 				] )
 			)->add_field(
 				new Field( self::NAME . '_' . self::LAYOUT, [

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
@@ -26,10 +26,10 @@ class Lead_Form extends Block_Config {
 	public const WIDTH_GRID = 'grid';
 	public const WIDTH_FULL = 'full';
 
+	public const PAGE_THEME_OVERRIDE = 'page_theme_override';
 	public const COLOR_THEME         = 'color_theme';
-	public const COLOR_THEME_DEFAULT = 'rgba(0,0,0,0)'; // transparent.
+	public const COLOR_THEME_DEFAULT = '#FFF'; // transparent.
 	public const COLOR_THEME_CHOICES = [
-		self::COLOR_THEME_DEFAULT => 'Page Theme',
 		'#FFF'                    => 'Light',
 		'#000'                    => 'Dark',
 	];
@@ -122,13 +122,30 @@ class Lead_Form extends Block_Config {
 				'default_value'   => self::WIDTH_GRID,
 				] )
 			)->add_field(
+				new Field( self::NAME . '_' . self::PAGE_THEME_OVERRIDE, [
+					'type'  => 'true_false',
+					'name'  => self::PAGE_THEME_OVERRIDE,
+					'label' => __( 'Override Page Theme', 'tribe' ),
+					'ui'    => true,
+				] )
+			)->add_field(
 				new Field( self::NAME . '_' . self::COLOR_THEME, [
-					'type'          => 'swatch',
-					'name'          => self::COLOR_THEME,
-					'label'         => __( 'Color Theme', 'tribe' ),
-					'choices'       => self::COLOR_THEME_CHOICES,
-					'allow_null'    => false,
-					'default_value' => self::COLOR_THEME_DEFAULT,
+					'type'              => 'swatch',
+					'name'              => self::COLOR_THEME,
+					'label'             => __( 'Color Theme', 'tribe' ),
+					'choices'           => self::COLOR_THEME_CHOICES,
+					'allow_null'        => false,
+					'allow_other'       => true,
+					'default_value'     => self::COLOR_THEME_DEFAULT,
+					'conditional_logic' => [
+						[
+							[
+								'field'    => 'field_' . self::NAME . '_' . self::PAGE_THEME_OVERRIDE,
+								'operator' => '==',
+								'value'    => '1',
+							]
+						]
+					],
 				] )
 			)->add_field(
 				new Field( self::NAME . '_' . self::LAYOUT, [

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
@@ -123,12 +123,12 @@ class Lead_Form extends Block_Config {
 				] )
 			)->add_field(
 				new Field( self::NAME . '_' . self::COLOR_THEME, [
-					'type'            => 'swatch',
-					'name'            => self::COLOR_THEME,
-					'label'           => __( 'Color Theme', 'tribe' ),
-					'choices'         => self::COLOR_THEME_CHOICES,
-					'allow_null'      => false,
-					'default_value'   => self::COLOR_THEME_DEFAULT,
+					'type'          => 'swatch',
+					'name'          => self::COLOR_THEME,
+					'label'         => __( 'Color Theme', 'tribe' ),
+					'choices'       => self::COLOR_THEME_CHOICES,
+					'allow_null'    => false,
+					'default_value' => self::COLOR_THEME_DEFAULT,
 				] )
 			)->add_field(
 				new Field( self::NAME . '_' . self::LAYOUT, [

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
@@ -26,9 +26,10 @@ class Lead_Form extends Block_Config {
 	public const WIDTH_GRID = 'grid';
 	public const WIDTH_FULL = 'full';
 
-	public const BACKGROUND       = 'background';
-	public const BACKGROUND_LIGHT = 'background_light';
-	public const BACKGROUND_DARK  = 'background_dark';
+	public const COLOR_THEME         = 'color_theme';
+	public const COLOR_THEME_INHERIT = 'rgba(0,0,0,0)'; // transparent.
+	public const COLOR_THEME_LIGHT   = '#FFF';
+	public const COLOR_THEME_DARK    = '#000';
 
 	public const FORM_FIELDS  = 'form_fields';
 	public const FORM_STACKED = 'form_stacked';
@@ -118,15 +119,17 @@ class Lead_Form extends Block_Config {
 				'default_value'   => self::WIDTH_GRID,
 				] )
 			)->add_field(
-				new Field( self::NAME . '_' . self::BACKGROUND, [
-					'type'            => 'radio',
-					'name'            => self::BACKGROUND,
-					'label'           => __( 'Background Color', 'tribe' ),
+				new Field( self::NAME . '_' . self::COLOR_THEME, [
+					'type'            => 'swatch',
+					'name'            => self::COLOR_THEME,
+					'label'           => __( 'Color Theme', 'tribe' ),
 					'choices'         => [
-						self::BACKGROUND_LIGHT   => __( 'Light', 'tribe' ),
-						self::BACKGROUND_DARK    => __( 'Dark', 'tribe' ),
+						self::COLOR_THEME_INHERIT => __( 'Inherit From Page Theme', 'tribe' ),
+						self::COLOR_THEME_LIGHT   => __( 'Light', 'tribe' ),
+						self::COLOR_THEME_DARK    => __( 'Dark', 'tribe' ),
 					],
-					'default_value'   => self::BACKGROUND_LIGHT,
+					'allow_null'      => false,
+					'default_value'   => self::COLOR_THEME_INHERIT,
 				] )
 			)->add_field(
 				new Field( self::NAME . '_' . self::LAYOUT, [

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form.php
@@ -27,12 +27,12 @@ class Lead_Form extends Block_Config {
 	public const WIDTH_FULL = 'full';
 
 	public const COLOR_THEME         = 'color_theme';
-	public const COLOR_THEME_CHOICES = [
-		'rgba(0,0,0,0)' => 'Page Theme',
-		'#FFF'          => 'Light',
-		'#000'          => 'Dark',
-	];
 	public const COLOR_THEME_DEFAULT = 'rgba(0,0,0,0)'; // transparent.
+	public const COLOR_THEME_CHOICES = [
+		self::COLOR_THEME_DEFAULT => 'Page Theme',
+		'#FFF'                    => 'Light',
+		'#000'                    => 'Dark',
+	];
 
 	public const FORM_FIELDS  = 'form_fields';
 	public const FORM_STACKED = 'form_stacked';

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
@@ -20,7 +20,7 @@ class Lead_Form_Model extends Base_Model {
 			Lead_Form_Block_Controller::LEADIN      => $this->get( Lead_Form::LEAD_IN, '' ),
 			Lead_Form_Block_Controller::DESCRIPTION => $this->get( Lead_Form::DESCRIPTION, '' ),
 			Lead_Form_Block_Controller::CTA         => $this->get_cta_args(),
-			Lead_Form_Block_Controller::COLOR_THEME => $this->get( Lead_Form::COLOR_THEME, Lead_Form::COLOR_THEME_LIGHT ),
+			Lead_Form_Block_Controller::COLOR_THEME => $this->get( Lead_Form::COLOR_THEME, Lead_Form::COLOR_THEME_DEFAULT ),
 			Lead_Form_Block_Controller::FORM_FIELDS => $this->get( Lead_Form::FORM_FIELDS, Lead_Form::FORM_STACKED ),
 
 		];

--- a/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Lead_Form/Lead_Form_Model.php
@@ -20,7 +20,7 @@ class Lead_Form_Model extends Base_Model {
 			Lead_Form_Block_Controller::LEADIN      => $this->get( Lead_Form::LEAD_IN, '' ),
 			Lead_Form_Block_Controller::DESCRIPTION => $this->get( Lead_Form::DESCRIPTION, '' ),
 			Lead_Form_Block_Controller::CTA         => $this->get_cta_args(),
-			Lead_Form_Block_Controller::BACKGROUND  => $this->get( Lead_Form::BACKGROUND, Lead_Form::BACKGROUND_LIGHT ),
+			Lead_Form_Block_Controller::COLOR_THEME => $this->get( Lead_Form::COLOR_THEME, Lead_Form::COLOR_THEME_LIGHT ),
 			Lead_Form_Block_Controller::FORM_FIELDS => $this->get( Lead_Form::FORM_FIELDS, Lead_Form::FORM_STACKED ),
 
 		];

--- a/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
+++ b/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
@@ -6,6 +6,7 @@ namespace Tribe\Project\Object_Meta;
 use DI;
 use Psr\Container\ContainerInterface;
 use Tribe\Libs\Container\Definer_Interface;
+use Tribe\Project\Post_Types\Page\Page;
 use Tribe\Project\Settings;
 
 class Object_Meta_Definer implements Definer_Interface {
@@ -15,6 +16,7 @@ class Object_Meta_Definer implements Definer_Interface {
 			\Tribe\Libs\Object_Meta\Object_Meta_Definer::GROUPS => DI\add( [
 				DI\get( Analytics_Settings::class ),
 				DI\get( Social_Settings::class ),
+				DI\get( Page_Appearance::class ),
 			] ),
 
 			// add analytics settings to the general settings screen
@@ -30,6 +32,13 @@ class Object_Meta_Definer implements Definer_Interface {
 					'settings_pages' => [ $container->get( Settings\General::class )->get_slug() ],
 				] );
 			},
+
+			// add appearance settings to pages.
+			Page_Appearance::class                              => static function ( ContainerInterface $container ) {
+				return new Page_Appearance( [
+					'post_types' => [ Page::NAME ]
+				] );
+			}
 		];
 	}
 }

--- a/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
+++ b/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
@@ -20,21 +20,21 @@ class Object_Meta_Definer implements Definer_Interface {
 			] ),
 
 			// add analytics settings to the general settings screen
-			Analytics_Settings::class                           => static function ( ContainerInterface $container ) {
+			Analytics_Settings::class => static function ( ContainerInterface $container ) {
 				return new Analytics_Settings( [
 					'settings_pages' => [ $container->get( Settings\General::class )->get_slug() ],
 				] );
 			},
 
 			// add social settings to the general settings screen
-			Social_Settings::class                              => static function ( ContainerInterface $container ) {
+			Social_Settings::class => static function ( ContainerInterface $container ) {
 				return new Social_Settings( [
 					'settings_pages' => [ $container->get( Settings\General::class )->get_slug() ],
 				] );
 			},
 
 			// add appearance settings to pages.
-			Page_Appearance::class                              => static function ( ContainerInterface $container ) {
+			Page_Appearance::class => static function ( ContainerInterface $container ) {
 				return new Page_Appearance( [
 					'post_types' => [ Page::NAME ]
 				] );

--- a/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
+++ b/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
@@ -10,6 +10,11 @@ class Page_Appearance extends ACF\ACF_Meta_Group {
 	public const NAME = 'page_appearance';
 
 	public const COLOR_THEME = 'color_theme';
+	public const COLOR_THEME_CHOICES = [
+		'#FFF' => 'Light',
+		'#000' => 'Dark',
+		'blue' => 'Blue',
+	];
 
 	public function get_keys(): array {
 		return [
@@ -30,15 +35,11 @@ class Page_Appearance extends ACF\ACF_Meta_Group {
 
 		$field = new ACF\Field( self::NAME . '_' . self::COLOR_THEME );
 		$field->set_attributes( [
-				'label' => 'Color Theme',
+				'label' => __( 'Color Theme', 'tribe' ),
 				'name' => 'color_theme',
 				'type' => 'swatch',
-				'choices' => [
-					'#FFF' => 'Light',
-					'#000' => 'Dark',
-					'blue' => 'Blue',
-				],
-				'allow_null' => 0,
+				'choices' => self::COLOR_THEME_CHOICES,
+				'allow_null' => false,
 			] );
 
 		return $field;

--- a/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
+++ b/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
@@ -17,7 +17,7 @@ class Page_Appearance extends ACF\ACF_Meta_Group {
 
 	public function get_keys(): array {
 		return [
-			static::COLOR_THEME
+			self::COLOR_THEME
 		];
 	}
 

--- a/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
+++ b/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Object_Meta;
+
+use Tribe\Libs\ACF;
+use Tribe\Project\Post_Types\Page\Page;
+
+class Page_Appearance extends ACF\ACF_Meta_Group {
+
+	public const NAME = 'page_appearance';
+
+	public const COLOR_THEME = 'color_theme';
+
+	public function get_keys(): array {
+		return [
+			static::COLOR_THEME
+		];
+	}
+
+	public function get_group_config(): array {
+		$group = new ACF\Group( self::NAME, $this->object_types );
+		$group->set_post_types( [ Page::NAME ] );
+		$group->set( 'title', __( 'Page Appearance', 'tribe' ) );
+		$group->add_field( $this->get_color_theme_field() );
+
+		return $group->get_attributes();
+	}
+
+	private function get_color_theme_field(): ACF\Field {
+
+		$field = new ACF\Field( self::NAME . '_' . self::COLOR_THEME );
+		$field->set_attributes( [
+				'label' => 'Color Theme',
+				'name' => 'color_theme',
+				'type' => 'swatch',
+				'choices' => [
+					'#FFF' => 'Light',
+					'#000' => 'Dark',
+					'blue' => 'Blue',
+				],
+				'allow_null' => 0,
+			] );
+
+		return $field;
+	}
+}

--- a/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
+++ b/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
@@ -13,7 +13,6 @@ class Page_Appearance extends ACF\ACF_Meta_Group {
 	public const COLOR_THEME_CHOICES = [
 		'#FFF' => 'Light',
 		'#000' => 'Dark',
-		'blue' => 'Blue',
 	];
 
 	public function get_keys(): array {

--- a/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
+++ b/wp-content/plugins/core/src/Object_Meta/Page_Appearance.php
@@ -34,10 +34,10 @@ class Page_Appearance extends ACF\ACF_Meta_Group {
 
 		$field = new ACF\Field( self::NAME . '_' . self::COLOR_THEME );
 		$field->set_attributes( [
-				'label' => __( 'Color Theme', 'tribe' ),
-				'name' => 'color_theme',
-				'type' => 'swatch',
-				'choices' => self::COLOR_THEME_CHOICES,
+				'label'      => __( 'Color Theme', 'tribe' ),
+				'name'       => 'color_theme',
+				'type'       => 'swatch',
+				'choices'    => self::COLOR_THEME_CHOICES,
 				'allow_null' => false,
 			] );
 

--- a/wp-content/themes/core/components/blocks/lead_form/Lead_Form_Block_Controller.php
+++ b/wp-content/themes/core/components/blocks/lead_form/Lead_Form_Block_Controller.php
@@ -22,7 +22,7 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 	public const FORM_CLASSES      = 'form_classes';
 	public const CLASSES           = 'classes';
 	public const ATTRS             = 'attrs';
-	public const BACKGROUND        = 'background';
+	public const COLOR_THEME       = 'color_theme';
 	public const FORM_FIELDS       = 'form_fields';
 
 	private string $width;
@@ -35,7 +35,7 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 	private array  $form_classes;
 	private array  $classes;
 	private array  $attrs;
-	private string $background;
+	private string $color_theme;
 	private string $form_fields;
 
 	/**
@@ -54,7 +54,7 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 		$this->form_classes      = (array) $args[ self::FORM_CLASSES ];
 		$this->classes           = (array) $args[ self::CLASSES ];
 		$this->attrs             = (array) $args[ self::ATTRS ];
-		$this->background        = (string) $args[ self::BACKGROUND ];
+		$this->color_theme       = (string) $args[ self::COLOR_THEME ];
 		$this->form_fields       = (string) $args[ self::FORM_FIELDS ];
 	}
 
@@ -65,7 +65,7 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 		return [
 			self::WIDTH             => Lead_Form_Block::WIDTH_GRID,
 			self::LAYOUT            => Lead_Form_Block::LAYOUT_BOTTOM,
-			self::BACKGROUND        => Lead_Form_Block::BACKGROUND_LIGHT,
+			self::COLOR_THEME       => Lead_Form_Block::COLOR_THEME_LIGHT,
 			self::FORM_FIELDS       => Lead_Form_Block::FORM_STACKED,
 			self::TITLE             => '',
 			self::LEADIN            => '',
@@ -96,11 +96,6 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 		$this->classes[] = 'b-lead-form--layout-' . $this->layout;
 		$this->classes[] = 'b-lead-form--width-' . $this->width;
 
-		// CASE: Full Width and Background Dark
-		if ( $this->width === Lead_Form_Block::WIDTH_FULL && $this->background === Lead_Form_Block::BACKGROUND_DARK ) {
-			$this->classes[] = 't-theme--light';
-		}
-
 		if ( $this->width === Lead_Form_Block::WIDTH_GRID ) {
 			$this->classes[] = 'l-container';
 		}
@@ -116,6 +111,8 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 	 * @return string
 	 */
 	public function get_attrs(): string {
+		$this->attrs['style'] = '--' . self::COLOR_THEME . ': ' . $this->color_theme;
+
 		return Markup_Utils::concat_attrs( $this->attrs );
 	}
 
@@ -125,11 +122,6 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 	public function get_container_classes(): string {
 		if ( $this->width === Lead_Form_Block::WIDTH_FULL ) {
 			$this->container_classes[] = 'l-container';
-		}
-
-		// CASE: Grid Width and Background Dark
-		if ( $this->width === Lead_Form_Block::WIDTH_GRID && $this->background === Lead_Form_Block::BACKGROUND_DARK ) {
-			$this->container_classes[] = 't-theme--light';
 		}
 
 		return Markup_Utils::class_attribute( $this->container_classes );

--- a/wp-content/themes/core/components/blocks/lead_form/Lead_Form_Block_Controller.php
+++ b/wp-content/themes/core/components/blocks/lead_form/Lead_Form_Block_Controller.php
@@ -65,7 +65,7 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 		return [
 			self::WIDTH             => Lead_Form_Block::WIDTH_GRID,
 			self::LAYOUT            => Lead_Form_Block::LAYOUT_BOTTOM,
-			self::COLOR_THEME       => Lead_Form_Block::COLOR_THEME_LIGHT,
+			self::COLOR_THEME       => Lead_Form_Block::COLOR_THEME_DEFAULT,
 			self::FORM_FIELDS       => Lead_Form_Block::FORM_STACKED,
 			self::TITLE             => '',
 			self::LEADIN            => '',

--- a/wp-content/themes/core/components/blocks/lead_form/Lead_Form_Block_Controller.php
+++ b/wp-content/themes/core/components/blocks/lead_form/Lead_Form_Block_Controller.php
@@ -111,7 +111,7 @@ class Lead_Form_Block_Controller extends Abstract_Controller {
 	 * @return string
 	 */
 	public function get_attrs(): string {
-		$this->attrs['style'] = '--' . self::COLOR_THEME . ': ' . $this->color_theme;
+		$this->attrs['style'] = sprintf('--%s:%s', self::COLOR_THEME, $this->color_theme );
 
 		return Markup_Utils::concat_attrs( $this->attrs );
 	}


### PR DESCRIPTION
## What does this do/fix?
https://moderntribe.atlassian.net/browse/SQONE-566

Adds a new "Page Appearance" settings group for all pages to give users the ability to apply a global page theme (e.g. Dark or Light). Similarly, this adds a new "Color Theme" field to the `Lead_Form` block (as an example for devs) to give users the option to choose block specific styling (dark, light, or use the current page theme—the default).

![Annotation on 2021-04-30 at 16-04-21](https://user-images.githubusercontent.com/6947218/116748967-3b689980-a9ce-11eb-8c1b-4114d50f3b26.png)


## To Do
- [ ] When the "Page Theme" option in the block is selected, have the block fall back to that color theme
- [ ] Extract the block field functionality so that it can be easily applied to any block with minimal work

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

