### PR TITLE
Fix husky hooks phpcs from checking every PHP file on commit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2021.05
+* Fixed: Husky hooks commits from scanning all PHP files with phpcs and limits to our core plugin/theme.
 * Added: documentation to get PHPCS configured in VS Code.
 * Updated: use the WP_ENVIRONMENT_TYPE constant added in Core v5.5.
 * Added: enabled the legacy markup for Gravity Forms 2.5 by default (until we can update our theme framework).

--- a/package.json
+++ b/package.json
@@ -68,15 +68,13 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": [
-        "lint-staged"
-      ]
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {
-    "*.php": [
+    "wp-content/{*themes,plugins*}/core/**/*.php": [
       "php -l",
-      "./vendor/bin/phpcs --standard=./phpcs.xml --extensions=php --warning-severity=8 -s"
+      "./vendor/bin/phpcs --standard=./phpcs.xml --warning-severity=8 -s"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## What does this do/fix?

Stops husky hooks from running phpcs on every PHP file in the project and only looks in our core plugin/theme.

## QA

- Do some bad PHP in either `wp-content/plugins/core/ ` or `wp-content/themes/core/` and it will find it.
- Add a premium plugin to `wp-content/plugins` and it will no longer scan it.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a package.json/tool update
- [ ] No, I need help figuring out how to write the tests.

