### PR TITLE
WP_ENVIRONMENT_TYPE double define bugfix / properly enable glomar

### DIFF
--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -21,10 +21,7 @@
  *
  * @link https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/
  */
-define( 'WP_ENVIRONMENT_TYPE', 'development' );
-
-// Fallback for older environments.
-define( 'ENVIRONMENT', 'DEV' );
+define( 'WP_ENVIRONMENT_TYPE', 'local' );
 
 /*
  * React dev

--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -21,7 +21,7 @@
  *
  * @link https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/
  */
-define( 'WP_ENVIRONMENT_TYPE', 'local' );
+define( 'WP_ENVIRONMENT_TYPE', 'development' );
 
 /*
  * React dev

--- a/wp-config-environment.php
+++ b/wp-config-environment.php
@@ -3,7 +3,7 @@
  * Base environment configuration, loaded for all environments (including automated tests)
  */
 
-function tribe_isSSL() {
+function tribe_isSSL(): bool {
 	return ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' );
 }
 
@@ -51,12 +51,12 @@ if ( file_exists( __DIR__ . '/local-config.php' ) ) {
 // ==============================================================
 
 // Provide fallback if ENVIRONMENT is already present.
-if ( defined( 'ENVIRONMENT' ) ) {
+if ( defined( 'ENVIRONMENT' ) && ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
 	define( 'WP_ENVIRONMENT_TYPE', strtolower( ENVIRONMENT ) );
 }
 
 if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
-	define( 'WP_ENVIRONMENT_TYPE', 'production');
+	define( 'WP_ENVIRONMENT_TYPE', 'development' );
 }
 
 if ( ! isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
@@ -214,6 +214,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			if ( WP_DEBUG_LOG && is_string( WP_DEBUG_LOG ) ) {
 				ini_set( 'error_log', WP_DEBUG_LOG );
 			}
+
 			return $ret;
 		},
 		11

--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -65,7 +65,7 @@ class Force_Plugin_Activation {
 	public function __construct() {
 
 		// Always block non-production sites from search engines and random visitors.
-		if ( 'production' !== wp_get_environment_type() ) {
+		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) || WP_ENVIRONMENT_TYPE !== 'production' ) {
 			$this->force_active[] = 'tribe-glomar/tribe-glomar.php';
 		}
 
@@ -77,7 +77,7 @@ class Force_Plugin_Activation {
 		 * not set, so we should always look for the explicit definition before doing
 		 * anything here.
 		 */
-		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE == 'production' ) {
+		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'production' ) {
 			$this->force_deactive[] = 'tribe-glomar/tribe-glomar.php';
 			$this->force_active[]   = 'limit-login-attempts-reloaded/limit-login-attempts-reloaded.php';
 		}


### PR DESCRIPTION
## What does this do/fix?

- There wasn't a proper check of `WP_ENVIRONMENT_TYPE` before trying to set the environment based on the legacy `ENVIRONMENT` constant.
- With the existing configuration, tribe glomar is not automatically enabled out of the box and it should be. Someone will immediately notice if that's enabled on production, but it would take a long time for someone to notice their dev/staging server is open to the world.
- 
## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a configuration change
- [ ] No, I need help figuring out how to write the tests.

