### PR TITLE
Use GitHub provided GITHUB_TOKEN secret

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,8 +36,8 @@ Runs a build and deployment of the application to the appropriate environment to
 Multiple Secrets must be configured:
 1. `DEV_DEPLOY_REPO` - the WPE git repository for the target environment.
 2. `DEPLOY_PRIVATE_SSH_KEY` - an authorized SSH Private Key (the pub key is entered into the WPE control panel) with the target git repo
-3. `GITHUB_TOKEN` - This is an authorized github token for Composer installing packages from private/public repositories.
-4. `COMPOSER_ENV` - These are required environment variables needed for Composer.
+3. `COMPOSER_ENV` - These are required environment variables needed for Composer.
+4. `GITHUB_TOKEN` - (AUTOMATIC) This is an authorized GitHub token for Composer installing packages from private/public repositories. Note, GitHub automatically generates this for each repo. 
 
 ### Usage
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,7 +36,7 @@ Runs a build and deployment of the application to the appropriate environment to
 Multiple Secrets must be configured:
 1. `DEV_DEPLOY_REPO` - the WPE git repository for the target environment.
 2. `DEPLOY_PRIVATE_SSH_KEY` - an authorized SSH Private Key (the pub key is entered into the WPE control panel) with the target git repo
-3. `GH_TOKEN` - This is an authorized github token for Composer installing packages from private/public repositories.
+3. `GITHUB_TOKEN` - This is an authorized github token for Composer installing packages from private/public repositories.
 4. `COMPOSER_ENV` - These are required environment variables needed for Composer.
 
 ### Usage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           mkdir -p dev/docker/composer
           printf '{ "config": {}, "repositories": { "packagist": { "type": "composer", "url": "https://packagist.org" } } }' > dev/docker/composer/config.json
-          printf '{ "github-oauth": { "github.com": "%s" } }\n' "${{ secrets.GH_TOKEN }}" > dev/docker/composer/auth.json
+          printf '{ "github-oauth": { "github.com": "%s" } }\n' "${{ secrets.GITHUB_TOKEN }}" > dev/docker/composer/auth.json
 
       - name: Check for Cached Composer Dependencies
         id: cache-composer-dependencies

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ jobs:
       DEPLOY_FOLDER: ./deploy
       ENVIRONMENT: development
       DEPLOY_REPO: ${{ secrets.DEV_DEPLOY_REPO }}
-      COMPOSER_AUTH: '{ "github-oauth": { "github.com": "${{ secrets.GH_TOKEN }}" } }'
+      COMPOSER_AUTH: '{ "github-oauth": { "github.com": "${{ secrets.GITHUB_TOKEN }}" } }'
 
     steps:
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,7 +15,7 @@ jobs:
       DEPLOY_FOLDER: ./deploy
       ENVIRONMENT: production
       DEPLOY_REPO: ${{ secrets.PROD_DEPLOY_REPO }}
-      COMPOSER_AUTH: '{ "github-oauth": { "github.com": "${{ secrets.GH_TOKEN }}" } }'
+      COMPOSER_AUTH: '{ "github-oauth": { "github.com": "${{ secrets.GITHUB_TOKEN }}" } }'
 
     steps:
 

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -15,7 +15,7 @@ jobs:
       DEPLOY_FOLDER: ./deploy
       ENVIRONMENT: staging
       DEPLOY_REPO: ${{ secrets.STAGE_DEPLOY_REPO }}
-      COMPOSER_AUTH: '{ "github-oauth": { "github.com": "${{ secrets.GH_TOKEN }}" } }'
+      COMPOSER_AUTH: '{ "github-oauth": { "github.com": "${{ secrets.GITHUB_TOKEN }}" } }'
 
     steps:
 

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Add GitHub oAuth
         env:
-          TOKEN: ${{ secrets.GH_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: composer config --global github-oauth.github.com $TOKEN
 
       - name: Setup PHP extension cache


### PR DESCRIPTION
## What does this do/fix?

GitHub already provides us with secret token to use that has access to the current repo: https://docs.github.com/en/actions/reference/authentication-in-a-workflow

This way when cloning this framework a user no longer needs to create a GH_TOKEN manually.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests.
- [ ] No, I need help figuring out how to write the tests.

