### PR TITLE
[SQONE-603] Limit CI tests to only PR's against the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Codeception Tests
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
 


### PR DESCRIPTION
## What does this do/fix?

Makes CI run on the main branch for Push and Pull_Request. This should fix our  badge and also reduce unnecessary test runs.


