### PR TITLE
Fix eslint GitHub actions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,10 +8,18 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - name: Get Node.js version
+        id: nvm
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+      - run: yarn install
       - uses: reviewdog/action-eslint@v1
         with:
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
-          eslint_flags: 'wp-content/plugins/core/**.js wp-content/themes/core/**.js'
+          fail_on_error: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          eslint_flags: 'wp-content/{*themes,plugins*}/core/**/*.js'


### PR DESCRIPTION
## What does this do/fix?

Automated eslinting is broken via GitHub actions, this fixes it by:

- Automatically detecting the node version.
- Using yarn install instead of npm install.
- Using a proper glob pattern to detect changes in our core/theme plugin.
- Using the built in `GITHUB_TOKEN`.
- Properly failing on any errors.

## QA

- Break a JS file in the core theme or plugin when a branch is in PR and it should properly fail.
- Fix the issue and push and it should then the action should pass.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a GitHub action update
- [ ] No, I need help figuring out how to write the tests.

