### PR TITLE
Force types for Yoast open graph filters

### DIFF
--- a/wp-content/plugins/core/src/Integrations/Yoast_SEO/Yoast_SEO_Subscriber.php
+++ b/wp-content/plugins/core/src/Integrations/Yoast_SEO/Yoast_SEO_Subscriber.php
@@ -8,11 +8,11 @@ class Yoast_SEO_Subscriber extends Abstract_Subscriber {
 
 	public function register(): void {
 		add_filter( 'wpseo_opengraph_image_size', function ( $size ) {
-			return $this->container->get( Open_Graph::class )->customize_wpseo_opengraph_image_size( $size );
+			return $this->container->get( Open_Graph::class )->customize_wpseo_opengraph_image_size( (string) $size );
 		}, 10, 1 );
 
 		add_filter( 'wpseo_twitter_image_size', function ( $size ) {
-			return $this->container->get( Open_Graph::class )->customize_wpseo_twitter_image_size( $size );
+			return $this->container->get( Open_Graph::class )->customize_wpseo_twitter_image_size( (string) $size );
 		}, 10, 1 );
 
 		// Remove WP SEO json-ld output in favor of the included functions


### PR DESCRIPTION
## What does this do/fix?

- Future proofing this as ran into it on another project with strict types as Yoast passes `null` type by default.

## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

