### PR TITLE
Fix broken author link in single meta

### DIFF
--- a/wp-content/themes/core/components/routes/single/single.php
+++ b/wp-content/themes/core/components/routes/single/single.php
@@ -39,9 +39,7 @@ $c->render_header();
 
 					<li class="item-single__meta-author">
 						<?php _e( 'by', 'tribe' ); ?>
-						<a href="<?php the_author_link(); ?>" rel="author">
-							<?php the_author(); ?>
-						</a>
+						<?php the_author_link(); ?>
 					</li>
 
 				</ul>


### PR DESCRIPTION
## What does this do/fix?

- Fixes the broken author link in the single template
- Removes deprecated function `the_author();`

## QA

Fixes this:

![image](https://user-images.githubusercontent.com/1066195/120246223-d8685d80-c22c-11eb-8d65-0478547faa44.png)


## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because it's a template change.
- [ ] No, I need help figuring out how to write the tests.

