### PR TITLE
Proper wp_nav_menu() $args type

### DIFF
--- a/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
@@ -2,6 +2,8 @@
 
 namespace Tribe\Project\Nav_Menus;
 
+use stdClass;
+
 /**
  * Class Nav_Attribute_Filters
  *
@@ -12,57 +14,61 @@ class Nav_Attribute_Filters {
 	/**
 	 * Remove the ID attributed from the nav item
 	 *
-	 * @param string $menu_id The ID that is applied to the menu item's `<li>` element.
-	 * @param object $item    The current menu item.
-	 * @param array  $args    An array of wp_nav_menu() arguments.
-	 * @param int    $depth   Depth of menu item. Used for padding.
+	 * @param string    $menu_id The ID that is applied to the menu item's `<li>` element.
+	 * @param object    $item    The current menu item.
+	 * @param \stdClass $args    An object of {@see wp_nav_menu()} arguments.
+	 * @param int       $depth   Depth of menu item. Used for padding.
 	 *
 	 * @return string
 	 *
 	 * @filter nav_menu_item_id
 	 */
-	public function customize_nav_item_id( $menu_id, $item, $args, $depth ): string {
+	public function customize_nav_item_id( string $menu_id, object $item, stdClass $args, int $depth ): string {
 		return '';
 	}
 
 	/**
 	 * Customize the CSS classes applied to an <li> in the nav menu.
 	 *
-	 * @param array  $classes The CSS classes that are applied to the menu item's `<li>` element.
-	 * @param object $item    The current menu item.
-	 * @param array  $args    An array of {@see wp_nav_menu()} arguments
-	 * @param int    $depth   Depth of menu item. Used for padding.
+	 * @param array     $classes The CSS classes that are applied to the menu item's `<li>` element.
+	 * @param object    $item    The current menu item.
+	 * @param \stdClass $args    An object of {@see wp_nav_menu()} arguments.
+	 * @param int       $depth   Depth of menu item. Used for padding.
+	 *
+	 * @note   WP Core docs claim that $args is an array, but it comes in as an object thanks to casting in wp_nav_menu().
 	 *
 	 * @return array
 	 *
 	 * @filter nav_menu_css_class
 	 */
-	public function customize_nav_item_classes( $classes, $item, $args, $depth ): array {
-		$classes[] = $args['theme_location'] . '__list-item';
+	public function customize_nav_item_classes( array $classes, object $item, stdClass $args, int $depth ): array {
+		$theme_location = $args->theme_location;
+
+		$classes[] = $theme_location . '__list-item';
 
 		// Depth
-		$classes[] = $args['theme_location'] . '__list-item--depth-' . $depth;
+		$classes[] = $theme_location . '__list-item--depth-' . $depth;
 
 		// Has children items
 		if ( in_array( 'menu-item-has-children', $item->classes ) ) {
-			$classes[] = $args['theme_location'] . '__list-item--has-children';
+			$classes[] = $theme_location . '__list-item--has-children';
 		}
 
 		// Is Parent Item
 		if ( in_array( 'current-menu-parent', $item->classes ) ) {
-			$classes[] = $args['theme_location'] . '__list-item--is-current-parent';
+			$classes[] = $theme_location . '__list-item--is-current-parent';
 		}
 
 		// Is Current Item
 		if ( in_array( 'current-menu-item', $item->classes ) ) {
-			$classes[] = $args['theme_location'] . '__list-item--is-current';
+			$classes[] = $theme_location . '__list-item--is-current';
 		}
 
 		/**
 		 * Filter the array of classes to remove the classes added by WP Core.
 		 * Regex is designed to filter all classes defined in `_wp_menu_item_classes_by_context()`;
 		 */
-		$classes = array_filter( $classes, static function ( $class ) {
+		return array_filter( $classes, static function ( $class ) {
 
 			/**
 			 * Patterns used for matching:
@@ -76,38 +82,39 @@ class Nav_Attribute_Filters {
 
 			return ! preg_match( $pattern, $class );
 		} );
-
-		return $classes;
 	}
 
 	/**
 	 * Customize WP menu item anchor attributes
 	 *
-	 * @param array $atts {
-	 *     The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
+	 * @param array     $atts   {
+	 *                          The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
 	 *
-	 *     @type string $title  Title attribute.
-	 *     @type string $target Target attribute.
-	 *     @type string $rel    The rel attribute.
-	 *     @type string $href   The href attribute.
+	 * @type string     $title  Title attribute.
+	 * @type string     $target Target attribute.
+	 * @type string     $rel    The rel attribute.
+	 * @type string     $href   The href attribute.
 	 * }
-	 * @param object $item  The current menu item.
-	 * @param array  $args  An array of {@see wp_nav_menu()} arguments.
-	 * @param int    $depth Depth of menu item. Used for padding.
+	 *
+	 * @param object    $item   The current menu item.
+	 * @param \stdClass $args   An object of {@see wp_nav_menu()} arguments.
+	 * @param int       $depth  Depth of menu item. Used for padding.
 	 *
 	 * @return array
 	 *
 	 * @filter nav_menu_link_attributes
 	 */
-	public function customize_nav_item_anchor_atts( $atts, $item, $args, $depth ): array {
+	public function customize_nav_item_anchor_atts( array $atts, object $item, stdClass $args, int $depth ): array {
+		$theme_location = $args->theme_location;
+
 		$classes = [
-			$args['theme_location'] . '__action',
-			$args['theme_location'] . '__action--depth-' . $depth,
+			$theme_location . '__action',
+			$theme_location . '__action--depth-' . $depth,
 		];
 
 		// Has children items
 		if ( in_array( 'menu-item-has-children', $item->classes ) ) {
-			$classes[] = $args['theme_location'] . '__action--has-children';
+			$classes[] = $theme_location . '__action--has-children';
 		}
 
 		$atts['class'] = implode( ' ', array_unique( $classes ) );

--- a/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
@@ -30,7 +30,7 @@ class Nav_Attribute_Filters {
 	 *
 	 * @param array  $classes The CSS classes that are applied to the menu item's `<li>` element.
 	 * @param object $item    The current menu item.
-	 * @param array  $args    An array of {@see wp_nav_menu()} arguments.
+	 * @param array  $args    An array of {@see wp_nav_menu()} arguments
 	 * @param int    $depth   Depth of menu item. Used for padding.
 	 *
 	 * @return array
@@ -38,13 +38,6 @@ class Nav_Attribute_Filters {
 	 * @filter nav_menu_css_class
 	 */
 	public function customize_nav_item_classes( $classes, $item, $args, $depth ): array {
-
-		/*
-		 *  WP Core docs claim that $args is an array, but it comes
-		 * in as an object thanks to casting in wp_nav_menu()
-		 */
-		$args = (array) $args;
-
 		$classes[] = $args['theme_location'] . '__list-item';
 
 		// Depth
@@ -107,13 +100,6 @@ class Nav_Attribute_Filters {
 	 * @filter nav_menu_link_attributes
 	 */
 	public function customize_nav_item_anchor_atts( $atts, $item, $args, $depth ): array {
-
-		/*
-		 *  WP Core docs claim that $args is an array, but it comes
-		 * in as an object thanks to casting in wp_nav_menu()
-		 */
-		$args = (array) $args;
-
 		$classes = [
 			$args['theme_location'] . '__action',
 			$args['theme_location'] . '__action--depth-' . $depth,

--- a/wp-content/plugins/core/src/Nav_Menus/Nav_Menus_Subscriber.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Nav_Menus_Subscriber.php
@@ -17,16 +17,20 @@ class Nav_Menus_Subscriber extends Abstract_Subscriber {
 	}
 
 	private function nav_attributes(): void {
+		/**
+		 * WP Core docs claim that $args is an array, but it comes
+		 * in as an object thanks to casting in wp_nav_menu()
+		 */
 		add_filter( 'nav_menu_item_id', function ( $menu_id, $item, $args, $depth ) {
-			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_id( $menu_id, $item, $args, $depth );
+			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_id( $menu_id, $item, (array) $args, $depth );
 		}, 10, 4 );
 
 		add_filter( 'nav_menu_css_class', function ( $classes, $item, $args, $depth ) {
-			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_classes( $classes, $item, $args, $depth );
+			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_classes( $classes, $item, (array) $args, $depth );
 		}, 10, 4 );
 
 		add_filter( 'nav_menu_link_attributes', function ( $atts, $item, $args, $depth ) {
-			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_anchor_atts( $atts, $item, $args, $depth );
+			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_anchor_atts( $atts, $item, (array) $args, $depth );
 		}, 10, 4 );
 	}
 

--- a/wp-content/plugins/core/src/Nav_Menus/Nav_Menus_Subscriber.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Nav_Menus_Subscriber.php
@@ -17,20 +17,16 @@ class Nav_Menus_Subscriber extends Abstract_Subscriber {
 	}
 
 	private function nav_attributes(): void {
-		/**
-		 * WP Core docs claim that $args is an array, but it comes
-		 * in as an object thanks to casting in wp_nav_menu()
-		 */
 		add_filter( 'nav_menu_item_id', function ( $menu_id, $item, $args, $depth ) {
-			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_id( $menu_id, $item, (array) $args, $depth );
+			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_id( $menu_id, $item, $args, $depth );
 		}, 10, 4 );
 
 		add_filter( 'nav_menu_css_class', function ( $classes, $item, $args, $depth ) {
-			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_classes( $classes, $item, (array) $args, $depth );
+			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_classes( $classes, $item, $args, $depth );
 		}, 10, 4 );
 
 		add_filter( 'nav_menu_link_attributes', function ( $atts, $item, $args, $depth ) {
-			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_anchor_atts( $atts, $item, (array) $args, $depth );
+			return $this->container->get( Nav_Attribute_Filters::class )->customize_nav_item_anchor_atts( $atts, $item, $args, $depth );
 		}, 10, 4 );
 	}
 

--- a/wp-content/plugins/core/src/Nav_Menus/Walker/Walker_Nav_Menu_Primary.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Walker/Walker_Nav_Menu_Primary.php
@@ -25,6 +25,8 @@ class Walker_Nav_Menu_Primary extends \Walker_Nav_Menu {
 	 *
 	 * @see   Walker::start_lvl()
 	 *
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+	 *
 	 * @since 3.0.0
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = [] ) {
@@ -58,6 +60,8 @@ class Walker_Nav_Menu_Primary extends \Walker_Nav_Menu {
 	 * @param int    $id     Current item ID.
 	 *
 	 * @see   Walker::start_el()
+	 *
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 	 *
 	 * @since 3.0.0
 	 * @since 4.4.0 The {@see 'nav_menu_item_args'} filter was added.


### PR DESCRIPTION
## What does this do/fix?

Getting ahead of another casting issue we ran into on another project.

WordPress claims the $args are an array, but they cast it as an object in a function.

## QA

- Menus on the frontend will no longer throw an error once types are added. 

## Tests

Does this have tests?

- [ ] Yes
- [x] No
- [ ] No, I need help figuring out how to write the tests.

