### PR TITLE
fix fatal when WP_DEBUG_DISPLAY is set false. Also make some more con…

### DIFF
--- a/wp-config-environment.php
+++ b/wp-config-environment.php
@@ -118,8 +118,8 @@ $config_defaults = [
 	'NONCE_SALT'                     => '%%NONCE_SALT%%',
 
 	// Security Directives
-	'DISALLOW_FILE_EDIT'             => true,
-	'DISALLOW_FILE_MODS'             => true,
+	'DISALLOW_FILE_EDIT'             => tribe_getenv( 'DISALLOW_FILE_EDIT', true ),
+	'DISALLOW_FILE_MODS'             => tribe_getenv( 'DISALLOW_FILE_MODS', true ),
 	'FORCE_SSL_LOGIN'                => tribe_getenv( 'FORCE_SSL_LOGIN', true ),
 	'FORCE_SSL_ADMIN'                => tribe_getenv( 'FORCE_SSL_ADMIN', true ),
 
@@ -207,7 +207,7 @@ if ( empty( $GLOBALS['memcached_servers'] ) ) {
 // ==============================================================
 
 if ( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY ) {
-	ini_set( 'display_errors', 0 );
+	ini_set( 'display_errors', '0' );
 }
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {


### PR DESCRIPTION
Fixes a fatal in config when WP_DEBUG_DISPLAY was set false.

Also, adds some more config keys so they can be set by environment vars. 

## What does this do/fix?

```
Fatal error: Uncaught TypeError: ini_set() expects parameter 2 to be string, int given in /application/www/wp-config-environment.php:210 Stack trace: #0 /application/www/wp-config-environment.php(210): ini_set('display_errors', 0) #1 /application/www/wp-config.php(4): require('/application/ww...') #2 /application/www/wp/wp-load.php(42): require_once('/application/ww...') #3 /application/www/wp/wp-blog-header.php(13): require_once('/application/ww...') #4 /application/www/wp/index.php(17): require('/application/ww...') #5 {main} thrown in /application/www/wp-config-environment.php on line 210
```


## Tests

Does this have tests?

- [x] No, this doesn't need tests because it's a config change

