### PR TITLE
Bug/links block rendering

### DIFF
--- a/wp-content/themes/core/components/blocks/links/Links_Block_Controller.php
+++ b/wp-content/themes/core/components/blocks/links/Links_Block_Controller.php
@@ -239,7 +239,7 @@ class Links_Block_Controller extends Abstract_Controller {
 		return array_map( static function ( $row ) {
 			return [
 				Link_Controller::URL            => $row['g-cta']['link']['url'] ?? '',
-				Link_Controller::CONTENT        => $row['g-cta']['link']['title'] ?? $row['g-cta']['link']['url'],
+				Link_Controller::CONTENT        => $row['g-cta']['link']['title'] ?? '',
 				Link_Controller::TARGET         => $row['g-cta']['link']['target'] ?? '',
 				Link_Controller::ADD_ARIA_LABEL => $row['g-cta']['add_aria_label'] ?? '',
 				Link_Controller::ARIA_LABEL     => $row['g-cta']['aria_label'] ?? '',

--- a/wp-content/themes/core/components/blocks/links/css/links.pcss
+++ b/wp-content/themes/core/components/blocks/links/css/links.pcss
@@ -5,12 +5,10 @@
  * ----------------------------------------------------------------------------- */
 
 .b-links {
-
 	/* CASE: Layout Stacked is slightly different than content block inline layout */
 	.c-content-block--layout-inline {
 
 		.c-block__title {
-
 			@media (--viewport-medium) {
 				float: none;
 				width: 100%;
@@ -171,7 +169,7 @@
 
 		position: absolute;
 		left: 0;
-		top: 4px;
+		top: 0;
 		display: block;
 		color: currentColor;
 		content: var(--icon-chevron-right);

--- a/wp-content/themes/core/components/blocks/links/links.php
+++ b/wp-content/themes/core/components/blocks/links/links.php
@@ -8,9 +8,6 @@ use Tribe\Project\Templates\Components\blocks\links\Links_Block_Controller;
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 $c = Links_Block_Controller::factory( $args );
 
-if ( empty( $c->get_links() ) ) {
-	return;
-}
 ?>
 
 <section <?php echo $c->get_classes(); ?> <?php echo $c->get_attrs(); ?>>

--- a/wp-content/themes/core/components/blocks/links/links.php
+++ b/wp-content/themes/core/components/blocks/links/links.php
@@ -31,10 +31,12 @@ $c = Links_Block_Controller::factory( $args );
 			<?php if ( ! empty( $c->get_links() ) ) { ?>
 				<ul class="b-links__list">
 					<?php foreach ( $c->get_links() as $link ) { ?>
+						<?php if ( ! empty( ( $link['url'] ?? '') ) ) : ?>
 						<li class="b-links__list-item">
 							<?php get_template_part( 'components/link/link', null, $link ); ?>
 						</li>
-					<?php } ?>
+						<?php endif;
+					} ?>
 				</ul>
 			<?php } ?>
 		</div>

--- a/wp-content/themes/core/components/link/Link_Controller.php
+++ b/wp-content/themes/core/components/link/Link_Controller.php
@@ -83,6 +83,10 @@ class Link_Controller extends Abstract_Controller {
 	public function get_content(): string {
 		$content = $this->content;
 
+		if ( ! is_string( $content ) ) {
+			$content = (string) $content;
+		}
+
 		if ( $this->target === '_blank' ) {
 			$content .= $this->new_window_text();
 		}


### PR DESCRIPTION
## What does this do/fix?

1. The Links block renders nothing without list data. There is a content block above so this is confusing to the user as they add content and see nothing. All content added will now render.
2. The Link block uses nested repeaters that don't pass our null check in our Model->get method.  Why? ACF returns an array of data from repeaters, and the keys can have a null value for nested fields and in this case the links. This fixes the issue at the link controller level by checking for a null value and casting it back to a string.
3. Fixed an illegal offset warning error
4. Adjusted bullet character alignment for chrome issue.

## QA

Testing Instructions: 
1. Goto test link below.
2. VERIFY all content renders.
3. VERIFY when adding a new link to the repeater with no link added. Post Saved. No error.

Test Link:
- https://sq1-pr789.moderntribe.qa/wp-admin/post.php?post=7&action=edit

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/SQONE-629)
