### PR TITLE
Feature/sqone 289/404 page

### DIFF
--- a/wp-content/themes/core/components/routes/not_found/Not_Found_Controller.php
+++ b/wp-content/themes/core/components/routes/not_found/Not_Found_Controller.php
@@ -72,11 +72,8 @@ class Not_Found_Controller extends Abstract_Controller {
 	 * @return \Tribe\Project\Templates\Models\Breadcrumb[]
 	 */
 	protected function get_breadcrumbs(): array {
-		$page = get_option( 'page_for_posts' );
-		$url  = $page ? get_permalink( $page ) : home_url();
-
 		return [
-			new Breadcrumb( $url, __( 'News', 'tribe' ) ),
+			new Breadcrumb( '', __( 'Not Found', 'tribe' ) ),
 		];
 	}
 

--- a/wp-content/themes/core/components/routes/not_found/Not_Found_Controller.php
+++ b/wp-content/themes/core/components/routes/not_found/Not_Found_Controller.php
@@ -4,6 +4,7 @@ namespace Tribe\Project\Templates\Components\routes\not_found;
 
 use Tribe\Project\Templates\Components\Abstract_Controller;
 use Tribe\Project\Templates\Components\breadcrumbs\Breadcrumbs_Controller;
+use Tribe\Project\Templates\Components\search_form\Search_Form_Controller;
 use Tribe\Project\Templates\Components\sidebar\Sidebar_Controller;
 use Tribe\Project\Templates\Models\Breadcrumb;
 
@@ -76,6 +77,17 @@ class Not_Found_Controller extends Abstract_Controller {
 
 		return [
 			new Breadcrumb( $url, __( 'News', 'tribe' ) ),
+		];
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_search_form_args(): array {
+		return [
+			Search_Form_Controller::CLASSES     => [ 'c-search--full', 'search-results__form' ],
+			Search_Form_Controller::FORM_ID     => uniqid( 's-' ),
+			Search_Form_Controller::PLACEHOLDER => __( 'Search', 'tribe' ),
 		];
 	}
 

--- a/wp-content/themes/core/components/routes/not_found/css/not_found.pcss
+++ b/wp-content/themes/core/components/routes/not_found/css/not_found.pcss
@@ -1,0 +1,30 @@
+.not-found {
+	text-align: center;
+	margin: var(--spacer-60) 0;
+
+	@media (--viewport-medium) {
+		margin: var(--spacer-80) 0;
+	}
+}
+
+.not-found__title {
+
+}
+
+.no-found__content {
+	font-size: var(--font-size-body);
+	font-family: var(--font-family-serif);
+	max-width: var(--grid-7-col);
+	margin: var(--spacer-20) auto var(--spacer-60);
+
+	@media (--viewport-medium) {
+		margin-top: var(--spacer-30);
+		margin-bottom: 80px;
+	}
+}
+
+.no-found__search {
+	max-width: var(--grid-8-col);
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/wp-content/themes/core/components/routes/not_found/index.pcss
+++ b/wp-content/themes/core/components/routes/not_found/index.pcss
@@ -1,0 +1,10 @@
+/* -----------------------------------------------------------------------------
+ *
+ * Component: Not Found
+ *
+ * This file is just a clearing-house, see the css directory
+ * and edit the source files found there.
+ *
+ * ----------------------------------------------------------------------------- */
+
+@import "css/not_found.pcss";

--- a/wp-content/themes/core/components/routes/not_found/not_found.php
+++ b/wp-content/themes/core/components/routes/not_found/not_found.php
@@ -9,17 +9,24 @@ $c->render_header();
 	<main id="main-content">
 		<?php $c->render_breadcrumbs(); ?>
 
-		<div class="l-container">
+		<div class="l-container t-sink">
 
 			<div class="not-found">
 
-				<h3 class="not-found__title">
-					<?php echo esc_html( __( '404 Page Not Found' ) ); ?>
+				<h3 class="not-found__title h1">
+					<?php echo esc_html( __( 'Error 404: I’m pretty sure you broke it' ) ); ?>
 				</h3>
 
 				<p class="no-found__content">
-					<?php echo esc_html( __( 'The content you are looking for does not exist.' ) ); ?>
+					<?php printf(
+						__( 'Start over from <a href="%s">home</a>, use the navigation to get back on track or search for something.' ),
+						esc_url( get_site_url() ),
+					); ?>
 				</p>
+
+				<div class="no-found__search">
+					<?php get_template_part( 'components/search_form/search_form', null, $c->get_search_form_args() ); ?>
+				</div>
 
 			</div>
 


### PR DESCRIPTION
## What does this do/fix?

Adds 404 not found page styles as per [figma design](https://www.figma.com/file/Wj2g7HVyBQWYIuxgNKMCxf/SQ1-Main-Patterns?node-id=5472%3A202)

Questions:
- Should we completely remove breadcrumbs here? Or change it to something else? (Currently has text `not found` with no link)


## QA
[Link to ticket](https://moderntribe.atlassian.net/browse/SQONE-289)

