### PR TITLE
Feature/sqone 643/move post archive settings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2021.06
+* Updated: Moved Post Archive settings from General Settings to post archive settings
 * Added Styles for the Not Found Page
 * Added: Styles and additional functionality to the search template.
 * Fixed: PHPCS workflow from not running when set as "Require status checks to pass before merging" if no files changed;

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
     "mt-a11y-dialog": "^5.1.1",
-    "object-hash": "^2.0.0",
+    "object-hash": "^2.2.0",
     "object-to-formdata": "^2.1.2",
     "prop-types": "^15.7.2",
     "query-string": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^5.3.2",
     "webpack-bundle-analyzer": "^3.6.0",
-    "webpack-cli": "^4.1.0",
+    "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^4.2.2",
     "webpack-merge-and-include-globally": "^2.1.20",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
     "spin.js": "^4.1.0",
-    "swiper": "^6.4.15",
+    "swiper": "^6.7.0",
     "verge": "^1.10.2",
     "voca": "^1.4.0",
     "whatwg-fetch": "^3.0.0",

--- a/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
+++ b/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
@@ -37,7 +37,7 @@ class Object_Meta_Definer implements Definer_Interface {
 
 			Post_Archive_Settings::class                        => static function ( ContainerInterface $container ) {
 				return new Post_Archive_Settings( [
-					'settings_pages' => [ $container->get( Settings\General::class )->get_slug() ],
+					'settings_pages' => [ $container->get( Settings\Post_Settings::class )->get_slug() ],
 				] );
 			},
 

--- a/wp-content/plugins/core/src/Settings/Post_Settings.php
+++ b/wp-content/plugins/core/src/Settings/Post_Settings.php
@@ -6,15 +6,15 @@ use Tribe\Libs\ACF\ACF_Settings;
 
 class Post_Settings extends ACF_Settings {
 
-	public function get_title() {
+	public function get_title(): string {
 		return __( 'Settings', 'tribe' );
 	}
 
-	public function get_capability() {
+	public function get_capability(): string {
 		return 'activate_plugins';
 	}
 
-	public function get_parent_slug() {
+	public function get_parent_slug(): string {
 		return 'edit.php';
 	}
 

--- a/wp-content/plugins/core/src/Settings/Post_Settings.php
+++ b/wp-content/plugins/core/src/Settings/Post_Settings.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Settings;
+
+use Tribe\Libs\ACF\ACF_Settings;
+
+class Post_Settings extends ACF_Settings {
+
+	public function get_title() {
+		return __( 'Settings', 'tribe' );
+	}
+
+	public function get_capability() {
+		return 'activate_plugins';
+	}
+
+	public function get_parent_slug() {
+		return 'edit.php';
+	}
+
+}

--- a/wp-content/plugins/core/src/Settings/Settings_Definer.php
+++ b/wp-content/plugins/core/src/Settings/Settings_Definer.php
@@ -13,6 +13,7 @@ class Settings_Definer implements Definer_Interface {
 			// add the settings screens to the global array
 			\Tribe\Libs\Settings\Settings_Definer::PAGES => DI\add( [
 				DI\get( General::class ),
+				DI\get( Post_Settings::class ),
 			] ),
 
 		];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9477,10 +9477,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-hash@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
-  integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-inspect@^1.7.0, object-inspect@^1.9.0:
   version "1.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13357,10 +13357,10 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-swiper@^6.4.15:
-  version "6.5.9"
-  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.5.9.tgz#ed6caa8bd9fd44d314944210551ce297d4fb09c7"
-  integrity sha512-zO3UCLVEiOXZontAQWBNpWFZGV3WaXwHSgvng0qIGLVMyxYGD6w78S7YkGAu/XBam1SBQNZzxqfFc/LDjNdq/A==
+swiper@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.7.0.tgz#ec971e703d03ef6196354140fbb22b074642bf5c"
+  integrity sha512-zCfvWn7H7mCq7jgVurckhAwkjPUeMCkdC4rA7lagvaD3mIrNhKiaYYo2+nkxMVpiaWuCQ38e44Mya/dKb7HpyQ==
   dependencies:
     dom7 "^3.0.0"
     ssr-window "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,22 +1750,22 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.3.tgz#204bcff87cda3ea4810881f7ea96e5f5321b87b9"
-  integrity sha512-WQs0ep98FXX2XBAfQpRbY0Ma6ADw8JR6xoIkaIiJIzClGOMqVRvPCWqndTxf28DgFopWan0EKtHtg/5W1h0Zkw==
+"@webpack-cli/configtest@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.4.tgz#f03ce6311c0883a83d04569e2c03c6238316d2aa"
+  integrity sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==
 
-"@webpack-cli/info@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.4.tgz#7381fd41c9577b2d8f6c2594fad397ef49ad5573"
-  integrity sha512-ogE2T4+pLhTTPS/8MM3IjHn0IYplKM4HbVNMCWA9N4NrdPzunwenpCsqKEXyejMfRu6K8mhauIPYf8ZxWG5O6g==
+"@webpack-cli/info@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.3.0.tgz#9d78a31101a960997a4acd41ffd9b9300627fe2b"
+  integrity sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==
   dependencies:
     envinfo "^7.7.3"
 
-"@webpack-cli/serve@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.4.0.tgz#f84fd07bcacefe56ce762925798871092f0f228e"
-  integrity sha512-xgT/HqJ+uLWGX+Mzufusl3cgjAcnqYYskaB7o0vRcwOEfuu6hMzSILQpnIzFMGsTaeaX4Nnekl+6fadLbl1/Vg==
+"@webpack-cli/serve@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.1.tgz#b5fde2f0f79c1e120307c415a4c1d5eb15a6f278"
+  integrity sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -14378,15 +14378,15 @@ webpack-bundle-analyzer@^3.6.0:
     opener "^1.5.1"
     ws "^6.0.0"
 
-webpack-cli@^4.1.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.7.0.tgz#3195a777f1f802ecda732f6c95d24c0004bc5a35"
-  integrity sha512-7bKr9182/sGfjFm+xdZSwgQuFjgEcy0iCTIBxRUeteJ2Kr8/Wz0qNJX+jw60LU36jApt4nmMkep6+W5AKhok6g==
+webpack-cli@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.7.2.tgz#a718db600de6d3906a4357e059ae584a89f4c1a5"
+  integrity sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^1.0.3"
-    "@webpack-cli/info" "^1.2.4"
-    "@webpack-cli/serve" "^1.4.0"
+    "@webpack-cli/configtest" "^1.0.4"
+    "@webpack-cli/info" "^1.3.0"
+    "@webpack-cli/serve" "^1.5.1"
     colorette "^1.2.1"
     commander "^7.0.0"
     execa "^5.0.0"


### PR DESCRIPTION
## What does this do/fix?

Moves the Post Archive Settings for Title, Description, and Image under the Post Settings screen. Previously this was a part of "General Settings" which was confusing. Moving it under the Post Menu is a better User Experience.


## QA

Links to relevant issues
- [JIRA TICKET](https://moderntribe.atlassian.net/browse/SQONE-643?atlOrigin=eyJpIjoiZDAwM2EwZTMzZGExNGFlZmE5YTczYjIwYjk0YzY2MjAiLCJwIjoiaiJ9)

Links to deployed, scaffolded demo:
- [Link to Demo](https://sq1-pr804.moderntribe.qa/wp-admin/edit.php?page=edit-php-settings&secret=1)

Screenshots/video:
- [Link to Video](http://p.tri.be/mUAMqq)

## Tests

Does this have tests?

- [x] No, this doesn't need tests because... it's a simple settings screen move.

