### PR TITLE
Bugfix/sqone 652/webpack public path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2021.07
+* Fixed: SQONE-652 webpack config for dynamic imports fixed for dev tasks. 
+
 ## 2021.06
 * Added styles and data handling for the index and archive pages.
 * Updated: Moved Post Archive settings from General Settings to post archive settings

--- a/webpack/admindev.js
+++ b/webpack/admindev.js
@@ -21,6 +21,7 @@ module.exports = merge.strategy( {
 	externals,
 	output: {
 		path: resolve( `${ __dirname }/../`, pkg.square1.paths.core_admin_js_dist ),
+		publicPath: `/${ pkg.square1.paths.core_admin_js_dist }`,
 	},
 	plugins: [
 		new MiniCssExtractPlugin( {

--- a/webpack/adminprod.js
+++ b/webpack/adminprod.js
@@ -22,6 +22,7 @@ module.exports = merge.strategy( {
 	externals,
 	output: {
 		path: resolve( `${ __dirname }/../`, pkg.square1.paths.core_admin_js_dist ),
+		publicPath: `/${ pkg.square1.paths.core_admin_js_dist }`,
 	},
 	plugins: [
 		new MiniCssExtractPlugin( {

--- a/webpack/themedev.js
+++ b/webpack/themedev.js
@@ -21,6 +21,7 @@ module.exports = merge.strategy( {
 	externals,
 	output: {
 		path: resolve( `${ __dirname }/../`, pkg.square1.paths.core_theme_js_dist ),
+		publicPath: `/${ pkg.square1.paths.core_theme_js_dist }`,
 	},
 	plugins: [
 		new MiniCssExtractPlugin( {

--- a/webpack/themeprod.js
+++ b/webpack/themeprod.js
@@ -24,6 +24,7 @@ module.exports = merge.strategy( {
 		externals,
 		output: {
 			path: resolve( `${ __dirname }/../`, pkg.square1.paths.core_theme_js_dist ),
+			publicPath: `/${ pkg.square1.paths.core_theme_js_dist }`,
 		},
 		plugins: [
 			new MiniCssExtractPlugin( {


### PR DESCRIPTION
## What does this do/fix?
Repairs the url path for dynamic imports in webpack while running the dev tasks. Without the publicPath property set, dynamic imports are referenced from the root of the site, not their correct path within the theme asset folders. 


## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/SQONE-652)

Screenshots/video:
- [Screenshot of broken path for dynamic import](http://p.tri.be/Y0SNsW)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a bug fix for the webpack configuration.
- [ ] No, I need help figuring out how to write the tests.

