### PR TITLE
SQONE-658 Remove duplication from compiled CSS

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2021.07
+* Fixed: SQONE-658: Update PostCSS config to remove duplicate selectors.
+
 ## 2021.06
 * Added styles and data handling for the index and archive pages.
 * Updated: Moved Post Archive settings from General Settings to post archive settings

--- a/gulp-tasks/postcss.js
+++ b/gulp-tasks/postcss.js
@@ -18,20 +18,27 @@ const sharedPlugins = [
 		],
 	} ),
 	require( 'postcss-mixins' ),
-	require( 'postcss-custom-properties' )( { preserve: true } ),
 	require( 'postcss-simple-vars' ),
-	require( 'postcss-custom-media' ),
 	require( 'postcss-functions' )( { functions: postcssFunctions } ),
 	require( 'postcss-quantity-queries' ),
 	require( 'postcss-aspect-ratio' ),
-	require( 'postcss-nested' ),
+	require( 'postcss-nested' ), // TODO: Investigate if postcss-nesting (https://github.com/jonathantneal/postcss-nesting) is more appropriate (CSSWG draft & supported by postcss-preset-env)
 	require( 'postcss-inline-svg' )( {
 		paths: [
 			pkg.square1.paths.core_theme_img,
 			pkg.square1.paths.core_admin_img,
 		],
 	} ),
-	require( 'postcss-preset-env' )( { stage: 0, autoprefixer: { grid: true }, features: { 'focus-visible-pseudo-class': false, 'focus-within-pseudo-class': false } } ),
+	require( 'postcss-preset-env' )( {
+		stage: 0,
+		autoprefixer: { grid: true },
+		preserve: false, // Comment this line to preserve CSS custom properties (css variables)
+		features: {
+			// 'custom-properties': false, // Uncomment this line to ONLY use CSS custom properties (no fallbacks)
+			'focus-visible-pseudo-class': false,
+			'focus-within-pseudo-class': false,
+		},
+	} ),
 	require( 'postcss-calc' ),
 ];
 
@@ -49,10 +56,9 @@ const legacyPlugins = [
 		prefix: '_',
 	} ),
 	require( 'postcss-mixins' ),
-	require( 'postcss-custom-properties' )( { preserve: false } ),
 	require( 'postcss-simple-vars' ),
 	require( 'postcss-nested' ),
-	require( 'postcss-preset-env' )( { browsers: [ 'last 20 versions' ] } ),
+	require( 'postcss-preset-env' )( { browsers: [ 'last 20 versions' ], preserve: false } ),
 	require( 'postcss-assets' )( { loadPaths: [ `${ pkg.square1.paths.core_theme }/` ] } ),
 ];
 

--- a/package.json
+++ b/package.json
@@ -181,8 +181,6 @@
     "postcss-aspect-ratio": "^1.0.0",
     "postcss-assets": "^5.0.0",
     "postcss-calc": "^7.0.1",
-    "postcss-custom-media": "^7.0.8",
-    "postcss-custom-properties": "^9.0.2",
     "postcss-functions": "^3.0.0",
     "postcss-import": "12.0.1",
     "postcss-import-ext-glob": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,7 +3545,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -7201,11 +7201,6 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip-regex@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
-  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
-
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -7620,13 +7615,6 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
-
-is-url-superb@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-3.0.0.tgz#b9a1da878a1ac73659047d1e6f4ef22c209d3e25"
-  integrity sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==
-  dependencies:
-    url-regex "^5.0.0"
 
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
@@ -10258,14 +10246,6 @@ postcss-custom-properties@^8.0.11:
     postcss "^7.0.17"
     postcss-values-parser "^2.0.1"
 
-postcss-custom-properties@^9.0.2:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-9.2.0.tgz#80bae0d6e0c510245ace7ede95ac527712ea24e7"
-  integrity sha512-IFRV7LwapFkNa3MtvFpw+MEhgyUpaVZ62VlR5EM0AbmnGbNhU9qIE8u02vgUbl1gLkHK6sterEavamVPOwdE8g==
-  dependencies:
-    postcss "^7.0.17"
-    postcss-values-parser "^3.0.5"
-
 postcss-custom-selectors@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz#64858c6eb2ecff2fb41d0b28c9dd7b3db4de7fba"
@@ -11155,16 +11135,6 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     flatten "^1.0.2"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
-
-postcss-values-parser@^3.0.5:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-3.2.1.tgz#55114607de6631338ba8728d3e9c15785adcc027"
-  integrity sha512-SQ7/88VE9LhJh9gc27/hqnSU/aZaREVJcRVccXBmajgP2RkjdJzNyH/a9GCVMI5nsRhT0jC5HpUMwfkz81DVVg==
-  dependencies:
-    color-name "^1.1.4"
-    is-url-superb "^3.0.0"
-    postcss "^7.0.5"
-    url-regex "^5.0.0"
 
 postcss-zindex@^2.0.1:
   version "2.2.0"
@@ -13550,11 +13520,6 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tlds@^1.203.0:
-  version "1.221.1"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.221.1.tgz#6cf6bff5eaf30c5618c5801c3f425a6dc61ca0ad"
-  integrity sha512-N1Afn/SLeOQRpxMwHBuNFJ3GvGrdtY4XPXKPFcx8he0U9Jg9ZkvTKE1k3jQDtCmlFn44UxjVtouF6PT4rEGd3Q==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -14042,14 +14007,6 @@ url-parse@^1.4.3, url-parse@^1.5.1:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-5.0.0.tgz#8f5456ab83d898d18b2f91753a702649b873273a"
-  integrity sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==
-  dependencies:
-    ip-regex "^4.1.0"
-    tlds "^1.203.0"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
## What does this do/fix?
Update PostCSS config to reduce compiled CSS duplication & provide documentation around PostCSS config options.

`postcss-preset-env` handles several of the transforms we had previously outlined independently in our CSS configuration. This change removes those duplicate transforms and adds some notes to the PostCSS config so devs may modify the config as needed on a project-by-project basis.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/SQONE-658)
- [Link to Slack conversation](https://tribe.slack.com/archives/G0166CKG8P7/p1627143504016300)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because this is a configuration change.
- [ ] No, I need help figuring out how to write the tests.

