### PR TITLE
Only allow force deactivated plugins to be activated with SQ1_DEBUG

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2021.07
+* Added: `SQ1_DEBUG` define allow force deactivated plugins to be enabled.
+* Updated: force-plugin-activation.php mu plugin to php7.4 and to use `SQ1_DEBUG` constant instead of `WP_DEBUG`.
+When `WP_ENVIRONMENT_TYPE` is set to `development`, it automatically sets `WP_DEBUG` to true if it's not already set
+and this can lead to unexpected behavior on environments without `WP_DEBUG` defined.
+  
 ## 2021.06
 * Added styles and data handling for the index and archive pages.
 * Updated: Moved Post Archive settings from General Settings to post archive settings

--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -54,3 +54,8 @@ define( 'WHOOPS_ENABLE', true );
  * If you would like to disable the plugin locally, add the following to your local-config.php.
  */
 define( 'TRIBE_GLOMAR', false );
+
+/*
+ * Set to true to allow force inactive plugins to be enabled.
+ */
+define( 'SQ1_DEBUG', false );

--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -2,14 +2,14 @@
 
 namespace Tribe\Mu;
 
-/*
-Plugin Name:	Force Plugin Activation/Deactivation
-Plugin URI: 	http://danieldvork.in
-Description:	Make sure the required plugins are always active.
-Version:    	1.0
-Author:     	Daniel Dvorkin
-Author URI: 	http://danieldvork.in
-*/
+/**
+ * Plugin Name:  Force Plugin Activation/Deactivation
+ * Plugin URI:   https://tri.be
+ * Description:  Make sure the required plugins are always active.
+ * Version:      1.0
+ * Author:       Modern Tribe
+ * Author URI:   https://tri.be
+ */
 
 class Force_Plugin_Activation {
 
@@ -21,31 +21,31 @@ class Force_Plugin_Activation {
 	 * @var string[]
 	 */
 	private array $force_active = [
+		'acf-image-select/acf-image-select.php',
 		'advanced-custom-fields-pro/acf.php',
 		'core/core.php',
 		'disable-emojis/disable-emojis.php',
-		'acf-image-select/acf-image-select.php',
 		'tribe-acf-post-list-field/tribe-acf-post-list-field.php',
 	];
 
 	/**
 	 * These plugins will be deactivated and can't
-	 * be activated unless WP_DEBUG is true.
+	 * be activated unless SQ1_DEBUG is true.
 	 *
 	 * Add elements as plugin path: directory/file.php
 	 *
 	 * @var string[]
 	 */
-	private array $force_deactivate = [
-		'debug-bar/debug-bar.php',
+	private array $force_inactive = [
 		'debug-bar-action-hooks/debug-bar-action-hooks.php',
 		'debug-bar-console/debug-bar-console.php',
 		'debug-bar-cron/debug-bar-cron.php',
 		'debug-bar-extender/debug-bar-extender.php',
+		'debug-bar/debug-bar.php',
 		'rewrite-rules-inspector/rewrite-rules-inspector.php',
 		'wp-log-in-browser/wp-log-in-browser.php',
-		'wp-xhprof-profiler/xhprof-profiler.php',
 		'wp-tota11y/wp-tota11y.php',
+		'wp-xhprof-profiler/xhprof-profiler.php',
 	];
 
 	/**
@@ -58,15 +58,15 @@ class Force_Plugin_Activation {
 	 */
 	private array $force_network_only = [
 		'advanced-custom-fields-pro/acf.php',
-		'debug-bar/debug-bar.php',
 		'debug-bar-action-hooks/debug-bar-action-hooks.php',
 		'debug-bar-console/debug-bar-console.php',
 		'debug-bar-cron/debug-bar-cron.php',
 		'debug-bar-extender/debug-bar-extender.php',
+		'debug-bar/debug-bar.php',
 		'rewrite-rules-inspector/rewrite-rules-inspector.php',
 		'wp-log-in-browser/wp-log-in-browser.php',
-		'wp-xhprof-profiler/xhprof-profiler.php',
 		'wp-tota11y/wp-tota11y.php',
+		'wp-xhprof-profiler/xhprof-profiler.php',
 	];
 
 	public function __construct() {
@@ -85,19 +85,19 @@ class Force_Plugin_Activation {
 		 * anything here.
 		 */
 		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'production' ) {
-			$this->force_deactivate[] = 'tribe-glomar/tribe-glomar.php';
-			$this->force_active[]     = 'limit-login-attempts-reloaded/limit-login-attempts-reloaded.php';
+			$this->force_inactive[] = 'tribe-glomar/tribe-glomar.php';
+			$this->force_active[]   = 'limit-login-attempts-reloaded/limit-login-attempts-reloaded.php';
 		}
 
 		// Specific config when unit tests are running
 		if ( defined( 'DIR_TESTDATA' ) && DIR_TESTDATA ) {
-			//$this->force_deactivate[] = 'term-sorter/term-sorter.php';
+			//$this->force_inactivate[] = 'term-sorter/term-sorter.php';
 		}
 
 		add_filter( 'option_active_plugins', [ $this, 'force_plugins' ], 10, 1 );
 		add_filter( 'site_option_active_sitewide_plugins', [ $this, 'force_plugins' ], 10, 1 );
-		add_filter( 'plugin_action_links', [ $this, 'plugin_action_links' ], 99, 4 );
-		add_filter( 'network_admin_plugin_action_links', [ $this, 'plugin_action_links' ], 99, 4 );
+		add_filter( 'plugin_action_links', [ $this, 'plugin_action_links' ], 99, 2 );
+		add_filter( 'network_admin_plugin_action_links', [ $this, 'plugin_action_links' ], 99, 2 );
 		add_filter( 'all_plugins', [ $this, 'hide_from_blog' ], 99, 1 );
 	}
 
@@ -109,35 +109,39 @@ class Force_Plugin_Activation {
 	 * @return array|bool
 	 */
 	public function force_plugins( $plugins ) {
-		/*
-		 * Occasionally it seems a boolean can be passed in here.
-		 */
+
+		// Occasionally it seems a boolean can be passed in here.
 		if ( ! is_array( $plugins ) ) {
 			return $plugins;
 		}
+
 		/*
 		 * WordPress works in mysterious ways
 		 * active_plugins has the plugin paths as array key and a number as value
 		 * active_sitewide_plugins has the number as key and the plugin path as value
 		 * I'm standardizing so we can run the array operations below, then flipping back if needed.
 		 */
-		if ( current_filter() == 'site_option_active_sitewide_plugins' ) {
+		if ( current_filter() === 'site_option_active_sitewide_plugins' ) {
 			$plugins = array_flip( $plugins );
+
+			if ( empty( $plugins ) ) {
+				return $plugins;
+			}
 		}
 
 		// Add our force-activated plugins
-		$plugins = array_merge( (array) $plugins, $this->force_active );
+		$plugins = array_merge( $plugins, $this->force_active );
 
-		// Remove our force-deactivated plugins unless WP_DEBUG is on. Forced removal when unit tests are running
-		if ( ( defined( 'DIR_TESTDATA' ) && DIR_TESTDATA ) || ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-			$plugins = array_diff( (array) $plugins, $this->force_deactivate );
+		// Remove our force-deactivated plugins unless SQ1_DEBUG is on. Forced removal when unit tests are running
+		if ( ( defined( 'DIR_TESTDATA' ) && DIR_TESTDATA ) || ! defined( 'SQ1_DEBUG' ) || ! SQ1_DEBUG ) {
+			$plugins = array_diff( $plugins, $this->force_inactive );
 		}
 
-		// Deduplicate
+		// Remove duplicates
 		$plugins = array_unique( $plugins );
 
 		// Flip back if needed (see comment above)
-		if ( current_filter() == 'site_option_active_sitewide_plugins' ) {
+		if ( current_filter() === 'site_option_active_sitewide_plugins' ) {
 			$plugins = array_flip( $plugins );
 		}
 
@@ -145,24 +149,22 @@ class Force_Plugin_Activation {
 	}
 
 	/**
-	 * Removes the activate/deactivate links from the plugins list
-	 * if they are in the force active or force deactivate lists.
+	 * Removes the activate/deactivate links from the plugins' list
+	 * if they are in the force active or force inactive lists.
 	 *
 	 * @param array  $actions
 	 * @param string $plugin_file
-	 * @param array  $plugin_data
-	 * @param string $context
 	 *
 	 * @return array
 	 */
-	public function plugin_action_links( $actions, $plugin_file, $plugin_data, $context ) {
+	public function plugin_action_links( array $actions, string $plugin_file ): array {
 
 		if ( in_array( $plugin_file, $this->force_active ) ) {
 			unset( $actions['deactivate'] );
 		}
 
-		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-			if ( in_array( $plugin_file, $this->force_deactivate ) ) {
+		if ( ! defined( 'SQ1_DEBUG' ) || ! SQ1_DEBUG ) {
+			if ( in_array( $plugin_file, $this->force_inactive ) ) {
 				unset( $actions['activate'] );
 			}
 		}
@@ -178,15 +180,16 @@ class Force_Plugin_Activation {
 	 *
 	 * @param array $plugins
 	 *
-	 * @return array mixed
+	 * @return string[]
 	 */
-	public function hide_from_blog( $plugins ) {
+	public function hide_from_blog( array $plugins ): array {
 
 		if ( ! is_multisite() ) {
 			return $plugins;
 		}
 
 		$screen = get_current_screen();
+
 		if ( $screen && $screen->in_admin( 'network' ) ) {
 			return $plugins;
 		}


### PR DESCRIPTION
## What does this do/fix?

If you're utilizing `WP_ENVIRONMENT_TYPE` defines on some hosts, setting that to `development` would lead to plugins being allowed active that should never. For example for clients using Jetpack or anything that publishes out to a 3rd party, those plugins would remain active if `WP_DEBUG` wasn't defined in the host's `wp-config.php` and lead to some unexpected surprises.

## QA

- Items in the `$force_inactive[]` array should not be able to be activated when `WP_ENVIRONMENT_TYPE` is not set to production.
- Defining `define( 'SQ1_DEBUG', true );` in your `wp-config.php` will allow those plugins to be activated, and if they were previously activated in the database, will now be active.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because...well...some tests could be good for this.
- [ ] No, I need help figuring out how to write the tests.

