### PR TITLE
Bugfix: single post missing the loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2021.07
+* Fixed: `the_date()` and `the_author_link()` not rendering anything on a post single.
+
 ## 2021.06
 * Added styles and data handling for the index and archive pages.
 * Updated: Moved Post Archive settings from General Settings to post archive settings

--- a/dev/tests/tests/acceptance.suite.yml
+++ b/dev/tests/tests/acceptance.suite.yml
@@ -9,7 +9,6 @@ modules:
         - \Helper\Acceptance
         - WPDb
         - WPBrowser
-        - WPLoader
     config:
         WPBrowser:
             url: '%ACCEPTANCE_WP_URL%'

--- a/dev/tests/tests/acceptance.suite.yml
+++ b/dev/tests/tests/acceptance.suite.yml
@@ -9,6 +9,7 @@ modules:
         - \Helper\Acceptance
         - WPDb
         - WPBrowser
+        - WPLoader
     config:
         WPBrowser:
             url: '%ACCEPTANCE_WP_URL%'

--- a/dev/tests/tests/acceptance/Tribe/Project/Post/SingleCest.php
+++ b/dev/tests/tests/acceptance/Tribe/Project/Post/SingleCest.php
@@ -13,7 +13,7 @@ class SingleCest {
 
 	public function post_should_display_date_and_author( AcceptanceTester $I ) {
 		$post_id = $I->havePostInDatabase( [
-			'post_status'  => 'publish',
+			'post_status' => 'publish',
 		] );
 
 		$posts_table = $I->grabPostsTableName();

--- a/dev/tests/tests/acceptance/Tribe/Project/Post/SingleCest.php
+++ b/dev/tests/tests/acceptance/Tribe/Project/Post/SingleCest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tribe\Project\Post;
+
+use AcceptanceTester;
+use DateTime;
+use DateTimeZone;
+
+class SingleCest {
+
+	public function _before( AcceptanceTester $I ) {
+	}
+
+	public function post_should_display_date_and_author( AcceptanceTester $I ) {
+		$post_id = $I->havePostInDatabase( [
+			'post_status'  => 'publish',
+		] );
+
+		$posts_table = $I->grabPostsTableName();
+		$post_date   = $I->grabFromDatabase( $posts_table, 'post_date', [
+			'ID' => $post_id,
+		] );
+
+		$options_table = $I->grabPrefixedTableNameFor( 'options' );
+		$date_format   = $I->grabFromDatabase( $options_table, 'option_value', [
+			'option_name' => 'date_format',
+		] );
+
+		$date = new DateTime( $post_date, new DateTimeZone( 'UTC' ) );
+
+		$I->amOnPage( "/?p=$post_id" );
+		$I->see( 'by admin', '.item-single__meta-author' );
+		$I->see( $date->format( $date_format ), 'time' );
+		$I->seeInSource( sprintf( '<time datetime="%s">', $date->format( 'c' ) ) );
+	}
+
+}

--- a/wp-content/themes/core/single.php
+++ b/wp-content/themes/core/single.php
@@ -1,3 +1,6 @@
 <?php declare(strict_types=1);
 
-get_template_part( 'routes/single/single' );
+while ( have_posts() ) {
+	the_post();
+	get_template_part( 'routes/single/single' );
+}


### PR DESCRIPTION
## What does this do/fix?

Currently a post single isn't properly set up in "the loop" so any post functions don't actually work e.g. `the_date()`, `the_author_link()` etc...

This is likely broken elsewhere as most templates do require a loop, some seem to set them up in the controller, though.

## QA

Before
![image](https://user-images.githubusercontent.com/1066195/128377309-f04890a1-0097-4b68-9742-92ffb40be0b1.png)

After
![image](https://user-images.githubusercontent.com/1066195/128377396-28070c66-3ef9-4b08-aafa-d48a6db5564c.png)


## Tests

Does this have tests?

- [x] Yes
- [ ] No, this doesn't need tests
- [ ] No, I need help figuring out how to write the tests.

