### PR TITLE
Fix duplicate keys/broken quote example

### DIFF
--- a/wp-content/plugins/core/src/Blocks/Types/Quote/Quote.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Quote/Quote.php
@@ -51,14 +51,9 @@ class Quote extends Block_Config {
 							'tribe'
 						),
 						self::GROUP_CITE => [
-							self::CITE_NAME => esc_html__( 'John Doe', 'tribe' ),
-						],
-						self::GROUP_CITE => [
+							self::CITE_NAME  => esc_html__( 'John Doe', 'tribe' ),
 							self::CITE_TITLE => esc_html__( 'Chief Executive', 'tribe' ),
-						],
-						self::GROUP_CITE => [
-							//Images are output as IDs so it's sort of hard to get an image value for preview
-							self::IMAGE => 0,
+							self::IMAGE      => 0,
 						],
 					],
 				],


### PR DESCRIPTION
## What does this do/fix?

- Fixes duplicate keys in the Quote block example so it renders the preview properly.

## QA

Block preview now shows values properly

![image](https://user-images.githubusercontent.com/1066195/128750524-2cfdb1d2-5386-4445-9881-92dfe114672c.png)


## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a block update.
- [ ] No, I need help figuring out how to write the tests.

