### PR TITLE
Bugfix/fe routes build

### DIFF
--- a/gulp-tasks/eslint.js
+++ b/gulp-tasks/eslint.js
@@ -42,6 +42,11 @@ module.exports = {
 			`${ pkg.square1.paths.core_theme_components }**/*.js`,
 		], pkg.square1.paths.core_theme_components );
 	},
+	routes() {
+		return lint( [
+			`${ pkg.square1.paths.core_theme_routes }**/*.js`,
+		], pkg.square1.paths.core_theme_routes );
+	},
 	integrations() {
 		return lint( [
 			`${ pkg.square1.paths.core_theme_integrations }**/*.js`,

--- a/gulp-tasks/stylelint.js
+++ b/gulp-tasks/stylelint.js
@@ -41,6 +41,18 @@ module.exports = {
 			} ) )
 			.pipe( gulp.dest( pkg.square1.paths.core_components_pcss ) );
 	},
+	routes() {
+		return gulp.src( [
+			`${ pkg.square1.paths.core_routes_pcss }**/*.pcss`,
+		] )
+			.pipe( stylelint( {
+				fix: true,
+				reporters: [
+					{ formatter: 'string', console: true },
+				],
+			} ) )
+			.pipe( gulp.dest( pkg.square1.paths.core_routes_pcss ) );
+	},
 	integrations() {
 		return gulp.src( [
 			`${ pkg.square1.paths.core_theme_integrations }**/*.pcss`,

--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -31,6 +31,7 @@ module.exports = {
 		gulp.watch( [
 			`${ pkg.square1.paths.core_theme_pcss }**/*.pcss`,
 			`${ pkg.square1.paths.core_theme_components }**/*.pcss`,
+			`${ pkg.square1.paths.core_theme_routes }**/*.pcss`,
 			`${ pkg.square1.paths.core_theme_integrations }**/*.pcss`,
 			`!${ pkg.square1.paths.core_theme_pcss }legacy.pcss`,
 			`!${ pkg.square1.paths.core_theme_pcss }content/page/_legacy.pcss`,
@@ -55,6 +56,7 @@ module.exports = {
 		gulp.watch( [
 			`${ pkg.square1.paths.core_theme_pcss }**/*.pcss`,
 			`${ pkg.square1.paths.core_theme_components }**/*.pcss`,
+			`${ pkg.square1.paths.core_theme_routes }**/*.pcss`,
 			//`${ pkg.square1.paths.core_theme_integrations }**/*.pcss`,
 			`${ pkg.square1.paths.core_admin_pcss }mce-editor.pcss`,
 			`!${ pkg.square1.paths.core_theme_pcss }legacy.pcss`,
@@ -66,6 +68,7 @@ module.exports = {
 		gulp.watch( [
 			`${ pkg.square1.paths.core_theme_pcss }**/*.pcss`,
 			`${ pkg.square1.paths.core_theme_components }**/*.pcss`,
+			`${ pkg.square1.paths.core_theme_routes }**/*.pcss`,
 			//`${ pkg.square1.paths.core_theme_integrations }**/*.pcss`,
 			`${ pkg.square1.paths.core_admin_pcss }block-editor.pcss`,
 			`${ pkg.square1.paths.core_admin_pcss }block-editor/**/*.pcss`,
@@ -95,6 +98,7 @@ module.exports = {
 		gulp.src( [
 			`${ pkg.square1.paths.core_theme_js_src }**/*.js`,
 			`${ pkg.square1.paths.core_theme_components }**/*.js`,
+			`${ pkg.square1.paths.core_theme_routes }**/*.js`,
 			`${ pkg.square1.paths.core_theme_integrations }**/*.js`,
 		] )
 			.pipe( webpackStream( merge( webpackThemeDevConfig, watchConfig ), null, function( err, stats ) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,6 +62,7 @@ const gulpTasks = [
 	'eslint:utils', // lint the utils js according to the products lint rules, uses fix to auto correct common issues
 	'eslint:admin', // lint the admin js according to the products lint rules, uses fix to auto correct common issues
 	'eslint:components', // lint the component js according to the products lint rules, uses fix to auto correct common issues
+	'eslint:routes', // lint the route js according to the products lint rules, uses fix to auto correct common issues
 	'eslint:integrations', // lint the integration js according to the products lint rules, uses fix to auto correct common issues
 
 	/* Footer tasks */
@@ -110,6 +111,7 @@ const gulpTasks = [
 	'stylelint:theme', // lints and fixes the theme pcss
 	'stylelint:apps', // lints and fixes the apps pcss modules
 	'stylelint:components', // lints and fixes the component pcss modules
+	'stylelint:routes', // lints and fixes the route pcss modules
 	'stylelint:integrations', // lints and fixes the integrations folder pcss
 
 	/* Watch Tasks (THESE MUST BE LAST) */
@@ -198,7 +200,11 @@ gulp.task( 'dev', gulp.parallel( watchTasks, async function() {
  */
 
 gulp.task( 'lint', gulp.series(
-	gulp.parallel( 'eslint:theme', 'eslint:apps', 'eslint:utils', 'eslint:admin', 'eslint:components', 'stylelint:theme', 'stylelint:apps', 'stylelint:components', 'stylelint:integrations' ),
+	gulp.parallel( 'eslint:theme', 'eslint:apps', 'eslint:utils', 'eslint:admin', 'eslint:components', 'eslint:routes', 'stylelint:theme', 'stylelint:apps', 'stylelint:components', 'stylelint:routes', 'stylelint:integrations' ),
+) );
+
+/**
+
 ) );
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "core_theme_fonts": "wp-content/themes/core/assets/fonts/theme/",
       "core_theme_pcss": "wp-content/themes/core/assets/css/src/theme/",
       "core_components_pcss": "wp-content/themes/core/components/",
+      "core_routes_pcss": "wp-content/themes/core/routes/",
       "core_apps_js_src": "wp-content/themes/core/assets/js/src/apps/",
       "core_utils_js_src": "wp-content/themes/core/assets/js/src/utils/",
       "core_admin_css": "wp-content/themes/core/assets/css/dist/admin/",

--- a/wp-content/themes/core/assets/css/src/theme/master.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/master.pcss
@@ -27,5 +27,8 @@
 /* All Components */
 @import-glob "../../../../components/**/index.pcss";
 
+/* All Routes */
+@import-glob "../../../../routes/**/index.pcss";
+
 /* All Integrations */
 @import-glob "../../../../integrations/**/index.pcss";


### PR DESCRIPTION
## What does this do/fix?

Adds build tasks for theme routes equivalent to theme components: gulp watch, eslint, stylelint, and glob importing.

CC: @defunctl 


## QA

Links to relevant issues
- https://github.com/moderntribe/square-one/pull/850/commits/7b438daba88e8606a10d3c7967a094874a219b0b

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because this only makes config.
- [ ] No, I need help figuring out how to write the tests.

