### PR TITLE
Fix invalid comment type and adjust for mt coding standards v2

### DIFF
--- a/wp-content/plugins/core/src/Theme/Pagination_Util.php
+++ b/wp-content/plugins/core/src/Theme/Pagination_Util.php
@@ -2,14 +2,13 @@
 
 namespace Tribe\Project\Theme;
 
+use WP_Query;
+
 class Pagination_Util {
 
-	/**
-	 * @var \WP_Query $query
-	 */
-	protected $query;
+	protected WP_Query $query;
 
-	public function __construct( ?\WP_Query $query = null ) {
+	public function __construct( ?WP_Query $query = null ) {
 		global $wp_query;
 
 		$this->query = $query ?? $wp_query;
@@ -18,14 +17,14 @@ class Pagination_Util {
 	/**
 	 * Returns an array of pagination number links.
 	 *
-	 * @param bool $links_offset    - the max # of links to show on either side of the current page. False for all pages.
+	 * @param int  $links_offset    - the max # of links to show on either side of the current page. False for all pages.
 	 * @param bool $show_next_prev  - show links for next/prev page.
 	 * @param bool $show_first_last - show links for first/last page.
 	 * @param bool $show_ellipses   - show ellipses when pages exist beyond offset on either side of current page.
 	 *
 	 * @return array
 	 */
-	public function numbers( $links_offset = false, $show_next_prev = true, $show_first_last = true, $show_ellipses = true ) {
+	public function numbers( int $links_offset = 0, bool $show_next_prev = true, bool $show_first_last = true, bool $show_ellipses = true ): array {
 		$links  = [];
 		$values = [];
 
@@ -36,8 +35,8 @@ class Pagination_Util {
 
 		$paged    = get_query_var( 'paged' ) ? absint( get_query_var( 'paged' ) ) : 1;
 		$max      = (int) $this->query->max_num_pages;
-		$is_first = $paged == 1;
-		$is_last  = $paged == $max;
+		$is_first = $paged === 1;
+		$is_last  = $paged === $max;
 
 		// Only add links on either side of current if we're not loading all the pages at once. Generate links for each applicable number we need to show.
 		if ( $links_offset ) {
@@ -74,7 +73,7 @@ class Pagination_Util {
 		// Sort the $links in case they're out of numeric order, then add any that we've generated so far to the return values.
 		sort( $links );
 		foreach ( $links as $link ) {
-			$active   = $paged == $link;
+			$active   = $paged === $link;
 			$values[] = $this->get_link_array( get_pagenum_link( $link ), (string) $link, [], $active );
 		}
 
@@ -108,7 +107,7 @@ class Pagination_Util {
 	 *
 	 * @return array
 	 */
-	protected function get_link_array( string $url, string $label, array $classes = [], bool $active = false, bool $next = false, bool $prev = false  ) {
+	protected function get_link_array( string $url, string $label, array $classes = [], bool $active = false, bool $next = false, bool $prev = false  ): array {
 		return [
 			'url'     => $url,
 			'label'   => $label,

--- a/wp-content/plugins/core/src/Theme/Pagination_Util.php
+++ b/wp-content/plugins/core/src/Theme/Pagination_Util.php
@@ -17,7 +17,7 @@ class Pagination_Util {
 	/**
 	 * Returns an array of pagination number links.
 	 *
-	 * @param int  $links_offset    - the max # of links to show on either side of the current page. False for all pages.
+	 * @param int  $links_offset    - the max # of links to show on either side of the current page. 0 for all pages.
 	 * @param bool $show_next_prev  - show links for next/prev page.
 	 * @param bool $show_first_last - show links for first/last page.
 	 * @param bool $show_ellipses   - show ellipses when pages exist beyond offset on either side of current page.

--- a/wp-content/themes/core/components/pagination/loop/Loop_Pagination_Controller.php
+++ b/wp-content/themes/core/components/pagination/loop/Loop_Pagination_Controller.php
@@ -9,54 +9,61 @@ use Tribe\Project\Theme\Pagination_Util;
 
 class Loop_Pagination_Controller extends Abstract_Controller {
 
-	public const CLASSES      = 'classes';
 	public const ATTRS        = 'attrs';
-	public const LIST_CLASSES = 'list_classes';
-	public const LIST_ATTRS   = 'list_attrs';
-	public const ITEM_CLASSES = 'item_classes';
+	public const CLASSES      = 'classes';
 	public const ITEM_ATTRS   = 'item_attrs';
+	public const ITEM_CLASSES = 'item_classes';
 	public const LINKS        = 'links';
+	public const LIST_ATTRS   = 'list_attrs';
+	public const LIST_CLASSES = 'list_classes';
 
-	private array $classes;
+	/**
+	 * @var string[]
+	 */
 	private array $attrs;
-	private array $list_classes;
-	private array $list_attrs;
-	private array $item_classes;
+
+	/**
+	 * @var string[]
+	 */
+	private array $classes;
+
+	/**
+	 * @var string[]
+	 */
 	private array $item_attrs;
+
+	/**
+	 * @var string[]
+	 */
+	private array $item_classes;
+
+	/**
+	 * @var string[]
+	 */
 	private array $links;
+
+	/**
+	 * @var string[]
+	 */
+	private array $list_attrs;
+
+	/**
+	 * @var string[]
+	 */
+	private array $list_classes;
 
 	private Pagination_Util $pagination;
 
 	public function __construct( Pagination_Util $pagination, array $args = [] ) {
 		$args = $this->parse_args( $args );
 
-		$this->classes      = (array) $args[ self::CLASSES ];
 		$this->attrs        = (array) $args[ self::ATTRS ];
-		$this->list_classes = (array) $args[ self::LIST_CLASSES ];
-		$this->list_attrs   = (array) $args[ self::LIST_ATTRS ];
-		$this->item_classes = (array) $args[ self::ITEM_CLASSES ];
+		$this->classes      = (array) $args[ self::CLASSES ];
 		$this->item_attrs   = (array) $args[ self::ITEM_ATTRS ];
+		$this->item_classes = (array) $args[ self::ITEM_CLASSES ];
+		$this->list_attrs   = (array) $args[ self::LIST_ATTRS ];
+		$this->list_classes = (array) $args[ self::LIST_CLASSES ];
 		$this->pagination   = $pagination;
-	}
-
-	protected function defaults(): array {
-		return [
-			self::CLASSES      => [],
-			self::ATTRS        => [],
-			self::LIST_CLASSES => [],
-			self::LIST_ATTRS   => [],
-			self::ITEM_CLASSES => [],
-			self::ITEM_ATTRS   => [],
-		];
-	}
-
-	protected function required(): array {
-		return [
-			self::CLASSES      => [ 'c-pagination', 'c-pagination--loop' ],
-			self::ATTRS        => [ 'aria-label' => esc_attr__( 'Loop Pagination', 'tribe' ) ],
-			self::LIST_CLASSES => [ 'c-pagination__list' ],
-			self::ITEM_CLASSES => [ 'c-pagination__item' ],
-		];
 	}
 
 	public function get_classes(): string {
@@ -91,7 +98,27 @@ class Loop_Pagination_Controller extends Abstract_Controller {
 		return $this->links;
 	}
 
-	protected function build_links(): array {
+	protected function defaults(): array {
+		return [
+			self::ATTRS        => [],
+			self::CLASSES      => [],
+			self::ITEM_ATTRS   => [],
+			self::ITEM_CLASSES => [],
+			self::LIST_ATTRS   => [],
+			self::LIST_CLASSES => [],
+		];
+	}
+
+	protected function required(): array {
+		return [
+			self::ATTRS        => [ 'aria-label' => esc_attr__( 'Loop Pagination', 'tribe' ) ],
+			self::CLASSES      => [ 'c-pagination', 'c-pagination--loop' ],
+			self::ITEM_CLASSES => [ 'c-pagination__item' ],
+			self::LIST_CLASSES => [ 'c-pagination__list' ],
+		];
+	}
+
+	private function build_links(): array {
 		$numbers = $this->pagination->numbers( 2, true, false, false );
 
 		if ( empty( $numbers ) ) {

--- a/wp-content/themes/core/components/pagination/loop/Loop_Pagination_Controller.php
+++ b/wp-content/themes/core/components/pagination/loop/Loop_Pagination_Controller.php
@@ -25,7 +25,9 @@ class Loop_Pagination_Controller extends Abstract_Controller {
 	private array $item_attrs;
 	private array $links;
 
-	public function __construct( array $args = [] ) {
+	private Pagination_Util $pagination;
+
+	public function __construct( Pagination_Util $pagination, array $args = [] ) {
 		$args = $this->parse_args( $args );
 
 		$this->classes      = (array) $args[ self::CLASSES ];
@@ -34,6 +36,7 @@ class Loop_Pagination_Controller extends Abstract_Controller {
 		$this->list_attrs   = (array) $args[ self::LIST_ATTRS ];
 		$this->item_classes = (array) $args[ self::ITEM_CLASSES ];
 		$this->item_attrs   = (array) $args[ self::ITEM_ATTRS ];
+		$this->pagination   = $pagination;
 	}
 
 	protected function defaults(): array {
@@ -88,9 +91,8 @@ class Loop_Pagination_Controller extends Abstract_Controller {
 		return $this->links;
 	}
 
-	private function build_links(): array {
-		$pagination = new Pagination_Util();
-		$numbers    = $pagination->numbers( 2, true, false, false );
+	protected function build_links(): array {
+		$numbers = $this->pagination->numbers( 2, true, false, false );
 
 		if ( empty( $numbers ) ) {
 			return [];


### PR DESCRIPTION
## What does this do/fix?

- When running phpcbf with the v2 standards, the `$links_offset` will be typed as a `bool` and will break since integers are being passed to it and it's used as an integer in the code. This updates it to the v2 standards.

## QA

- Pagination should work as before.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, but would likely benefit from them.
- [ ] No, I need help figuring out how to write the tests.

