### PR TITLE
fixes markup closing issue in comments

### DIFF
--- a/wp-content/themes/core/components/comments/comment/Comment_Controller.php
+++ b/wp-content/themes/core/components/comments/comment/Comment_Controller.php
@@ -124,7 +124,7 @@ class Comment_Controller extends Abstract_Controller {
 		return date( $format, get_comment_time( 'U' ) );
 	}
 
-	public function get_starting_markup_element(): string {
+	public function get_tag(): string {
 		$element = 'li';
 		if ( 'div' === $this->style ) {
 			$element = 'div';

--- a/wp-content/themes/core/components/comments/comment/Comment_Controller.php
+++ b/wp-content/themes/core/components/comments/comment/Comment_Controller.php
@@ -14,17 +14,19 @@ class Comment_Controller extends Abstract_Controller {
 
 	use Comment_Edit_Link;
 
-	public const COMMENT_ID = 'comment_id';
-	public const CLASSES    = 'classes';
 	public const ATTRS      = 'attrs';
+	public const CLASSES    = 'classes';
+	public const COMMENT_ID = 'comment_id';
 	public const DEPTH      = 'depth';
 	public const MAX_DEPTH  = 'max_depth';
+	public const STYLE      = 'style';
 
-	private int $comment_id;
-	private array $classes;
 	private array $attrs;
+	private array $classes;
+	private int $comment_id;
 	private int $depth;
 	private int $max_depth;
+	private string $style;
 
 	/**
 	 * Comment constructor.
@@ -34,11 +36,12 @@ class Comment_Controller extends Abstract_Controller {
 	public function __construct( array $args = [] ) {
 		$args = $this->parse_args( $args );
 
-		$this->comment_id = (int) $args[ self::COMMENT_ID ];
-		$this->classes    = (array) $args[ self::CLASSES ];
 		$this->attrs      = (array) $args[ self::ATTRS ];
+		$this->classes    = (array) $args[ self::CLASSES ];
+		$this->comment_id = (int) $args[ self::COMMENT_ID ];
 		$this->depth      = (int) $args[ self::DEPTH ];
 		$this->max_depth  = (int) $args[ self::MAX_DEPTH ];
+		$this->style      = (string) $args[ self::STYLE ];
 	}
 
 	/**
@@ -46,11 +49,12 @@ class Comment_Controller extends Abstract_Controller {
 	 */
 	protected function defaults(): array {
 		return [
-			self::COMMENT_ID => 0,
-			self::CLASSES    => [],
 			self::ATTRS      => [],
+			self::CLASSES    => [],
+			self::COMMENT_ID => 0,
 			self::DEPTH      => 0,
 			self::MAX_DEPTH  => - 1,
+			self::STYLE      => 'ol',
 		];
 	}
 
@@ -118,6 +122,15 @@ class Comment_Controller extends Abstract_Controller {
 
 	public function get_time( $format = 'c' ): string {
 		return date( $format, get_comment_time( 'U' ) );
+	}
+
+	public function get_starting_markup_element(): string {
+		$element = 'li';
+		if ( 'div' === $this->style ) {
+			$element = 'div';
+		}
+
+		return $element;
 	}
 
 }

--- a/wp-content/themes/core/components/comments/comment/comment.php
+++ b/wp-content/themes/core/components/comments/comment/comment.php
@@ -9,7 +9,7 @@ use \Tribe\Project\Templates\Components\comments\comment\Comment_Controller;
 $c = Comment_Controller::factory( $args );
 ?>
 
-<<?php echo $c->get_starting_markup_element(); ?> <?php echo $c->get_classes(); ?><?php echo $c->get_attrs(); ?>>
+<<?php echo $c->get_tag(); ?> <?php echo $c->get_classes(); ?><?php echo $c->get_attrs(); ?>>
 
 	<header class="comment__header">
 

--- a/wp-content/themes/core/components/comments/comment/comment.php
+++ b/wp-content/themes/core/components/comments/comment/comment.php
@@ -9,7 +9,7 @@ use \Tribe\Project\Templates\Components\comments\comment\Comment_Controller;
 $c = Comment_Controller::factory( $args );
 ?>
 
-<li <?php echo $c->get_classes(); ?><?php echo $c->get_attrs(); ?>>
+<<?php echo $c->get_starting_markup_element(); ?> <?php echo $c->get_classes(); ?><?php echo $c->get_attrs(); ?>>
 
 	<header class="comment__header">
 
@@ -37,5 +37,3 @@ $c = Comment_Controller::factory( $args );
 	); ?>
 
 	<?php echo $c->get_reply_link(); ?>
-
-</li>

--- a/wp-content/themes/core/components/comments/comments_section/Comments_Section_Controller.php
+++ b/wp-content/themes/core/components/comments/comments_section/Comments_Section_Controller.php
@@ -59,7 +59,10 @@ class Comments_Section_Controller extends Abstract_Controller {
 	/**
 	 * Renders a comment and echos it. This is the callback
 	 * for wp_list_comments(), and is expected to be called
-	 * in the context of an output buffer.
+	 * in the context of an output buffer. The callback is
+	 * called by the start_el method of the walker and
+	 * should not include a closing element. The closing
+	 * element is provided by the end_el method.
 	 *
 	 * @param \WP_Comment $comment
 	 * @param array       $args
@@ -89,6 +92,7 @@ class Comments_Section_Controller extends Abstract_Controller {
 			Comment_Controller::COMMENT_ID => $comment->comment_ID,
 			Comment_Controller::DEPTH      => $depth,
 			Comment_Controller::MAX_DEPTH  => $args['max_depth'],
+			Comment_Controller::STYLE      => $args['style'],
 		] );
 	}
 


### PR DESCRIPTION
## What does this do/fix?
Fixes an invalid markup error in comments markup.

When running the callback function in `Comments_Section_Controller::get_comments` we were returning the closing markup element. The callback is being called from the `start_el` of the walker which means that we shouldn't be closing the element, the `end_el` will handle that.

This PR also allows the comment controller to use the same comparison in order to output the element (li or div) based on the style in `wp_list_comments` the same way that the `end_el` method does for better compatibility.

## QA

Screenshots/video:
- [invalid HTML example Current Output](http://p.tri.be/AsbKC1)
- [Fixed HTML after PR applied](https://sq1-pr854.moderntribe.qa/hello-world/)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

