### PR TITLE
cast constant as string

### DIFF
--- a/wp-content/plugins/tribe-glomar/Tribe_Glomar.php
+++ b/wp-content/plugins/tribe-glomar/Tribe_Glomar.php
@@ -282,7 +282,7 @@ class Tribe_Glomar {
 			return;
 		}
 
-		setcookie( self::COOKIE, '1', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( self::COOKIE, '1', time() - YEAR_IN_SECONDS, COOKIEPATH, (string) COOKIE_DOMAIN );
 	}
 
 	/**


### PR DESCRIPTION
## What does this do/fix?

If `COOKIE_DOMAIN` is not a string, PHP throws an error that the fifth parameter to `setcookie()` expects a string; cast the constant as a string to prevent the error (match fix on https://github.com/moderntribe/square-one/blob/main/wp-content/plugins/tribe-glomar/Tribe_Glomar.php#L260).

## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/MSLOC-98
- https://gitlab.com/microsoft-stories/microsoft-monorepo/-/merge_requests/255

Links to deployed, scaffolded demo:
- https://microsoftlocal.wpengine.com

Screenshots/video:
- http://p.tri.be/2ezoIp

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

