### PR TITLE
Bugfix/sqone 664/reusable block width

### DIFF
--- a/wp-content/themes/core/assets/css/src/admin/block-editor/blocks.pcss
+++ b/wp-content/themes/core/assets/css/src/admin/block-editor/blocks.pcss
@@ -24,7 +24,8 @@
 		max-width: var(--grid-width-full-bleed);
 	}
 
-	/* CASE: the core "Reusable Pattern" block and core blocks within a block should be reset. */
+	/* CASE: the core "Reusable Pattern" & Group blocks and core blocks within a block should be reset. */
+	&.wp-block-group,
 	&.wp-block-block,
 	.c-block & {
 		width: 100%;

--- a/wp-content/themes/core/assets/css/src/admin/block-editor/blocks.pcss
+++ b/wp-content/themes/core/assets/css/src/admin/block-editor/blocks.pcss
@@ -24,7 +24,8 @@
 		max-width: var(--grid-width-full-bleed);
 	}
 
-	/* CASE: core blocks within a block should be reset. */
+	/* CASE: the core "Reusable Pattern" block and core blocks within a block should be reset. */
+	&.wp-block-block,
 	.c-block & {
 		width: 100%;
 		max-width: none;

--- a/wp-content/themes/core/assets/css/src/theme/layouts/default.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/layouts/default.pcss
@@ -71,7 +71,7 @@ main {
 
 .l-sink {
 
-	& > *:not(.c-block):not(.alignwide):not(.alignfull) {
+	& > *:not(.c-block):not(.wp-block-group):not(.alignwide):not(.alignfull) {
 		max-width: var(--grid-width-staggered);
 		width: calc(100% - 2 * var(--grid-gutter-small));
 		margin-left: auto;
@@ -98,7 +98,7 @@ main {
 
 .l-sink--double {
 
-	& > *:not(.c-block):not(.alignwide):not(.alignfull) {
+	& > *:not(.c-block):not(.wp-block-group):not(.alignwide):not(.alignfull) {
 		max-width: var(--grid-width-staggered-double);
 	}
 }

--- a/wp-content/themes/core/routes/unsupported_browser/css/unsupported-browser.pcss
+++ b/wp-content/themes/core/routes/unsupported_browser/css/unsupported-browser.pcss
@@ -119,7 +119,7 @@ a {
 	}
 
 	a {
-		color: var(--legacy-color-link)
+		color: var(--legacy-color-link);
 	}
 }
 


### PR DESCRIPTION
## What does this do/fix?
Updates our style selectors to allow the Core Reusable Pattern "block" and Group blocks to go full-width in the editor and within the `l-sink` context.

[Link to Issue](https://moderntribe.atlassian.net/browse/SQONE-664)
[Demo Link](https://sq1-pr861.moderntribe.qa/wp-admin/post.php?post=214&action=edit)
