### PR TITLE
SQONE-521 Add a generic navigation menu component.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2021.09
 * Fixed: Reusable & Group block width repair.
+* Added: Generic navigation menu component.
 
 ## 2021.08
 * Added: Block Deny List, removing the requirement to list all allowed blocks.

--- a/wp-content/themes/core/assets/js/src/theme/core/components.js
+++ b/wp-content/themes/core/assets/js/src/theme/core/components.js
@@ -7,6 +7,7 @@
 import accordion from 'components/accordion';
 import card from 'components/card';
 import comments from 'components/comments';
+import navigation from 'components/navigation';
 import share from 'components/share';
 import slider from 'components/slider';
 import tabs from 'components/tabs';
@@ -19,6 +20,7 @@ const init = () => {
 	accordion();
 	card();
 	comments();
+	navigation();
 	share();
 	slider();
 	tabs();

--- a/wp-content/themes/core/components/footer/navigation/navigation.php
+++ b/wp-content/themes/core/components/footer/navigation/navigation.php
@@ -15,8 +15,8 @@ if ( ! $c->has_menu() ) {
 
 <nav <?php echo $c->get_classes(); ?> <?php echo $c->get_attrs(); ?>>
 
-	<ol <?php echo $c->get_nav_list_classes(); ?>>
+	<ul <?php echo $c->get_nav_list_classes(); ?>>
 		<?php echo $c->get_menu(); ?>
-	</ol>
+	</ul>
 
 </nav>

--- a/wp-content/themes/core/components/navigation/Navigation_Controller.php
+++ b/wp-content/themes/core/components/navigation/Navigation_Controller.php
@@ -1,0 +1,81 @@
+<?php declare( strict_types=1 );
+
+namespace Tribe\Project\Templates\Components\navigation;
+
+use Tribe\Libs\Utils\Markup_Utils;
+use Tribe\Project\Nav_Menus\Menu;
+use Tribe\Project\Templates\Components\Abstract_Controller;
+
+class Navigation_Controller extends Abstract_Controller {
+
+	public const LOCATION         = 'location';
+	public const CLASSES          = 'classes';
+	public const ATTRS            = 'attrs';
+	public const NAV_LIST_CLASSES = 'nav_list_classes';
+	public const NAV_MENU_ARGS    = 'nav_menu_args';
+
+	private const DEFAULT_NAV_MENU_ARGS = [
+		'container'   => false,
+		'menu_class'  => '',
+		'menu_id'     => '',
+		'depth'       => 1,
+		'items_wrap'  => '%3$s',
+		'fallback_cb' => false,
+	];
+
+	private string $location;
+	private array $classes;
+	private array $attrs;
+	private array $nav_list_classes;
+	private array $nav_menu_args;
+
+	public function __construct( array $args = [] ) {
+		$args = $this->parse_args( $args );
+
+		$this->location         = (string) $args[ self::LOCATION ];
+		$this->classes          = (array) $args[ self::CLASSES ];
+		$this->attrs            = (array) $args[ self::ATTRS ];
+		$this->nav_list_classes = (array) $args[ self::NAV_LIST_CLASSES ];
+		$this->nav_menu_args    = $this->parse_menu_args( $args[ self::NAV_MENU_ARGS ] );
+	}
+
+	protected function defaults(): array {
+		return [
+			self::LOCATION         => '',
+			self::CLASSES          => [ 'c-nav' ],
+			self::ATTRS            => [],
+			self::NAV_LIST_CLASSES => [ 'c-nav__list' ],
+			self::NAV_MENU_ARGS    => [],
+		];
+	}
+
+	private function parse_menu_args( $menu_args ): array {
+		$menu_args['theme_location'] = $this->location;
+
+		return wp_parse_args( $menu_args, self::DEFAULT_NAV_MENU_ARGS );
+	}
+
+	public function has_menu(): bool {
+		return has_nav_menu( $this->location );
+	}
+
+	public function get_classes(): string {
+		return Markup_Utils::class_attribute( $this->classes );
+	}
+
+	public function get_attrs(): string {
+		return Markup_Utils::concat_attrs( $this->attrs );
+	}
+
+	public function get_nav_list_classes(): string {
+		return Markup_Utils::class_attribute( $this->nav_list_classes );
+	}
+
+	public function get_menu(): string {
+		if ( empty( $this->location ) ) {
+			return '';
+		}
+
+		return Menu::menu( $this->nav_menu_args );
+	}
+}

--- a/wp-content/themes/core/components/navigation/Navigation_Controller.php
+++ b/wp-content/themes/core/components/navigation/Navigation_Controller.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tribe\Project\Templates\Components\navigation;
 
@@ -78,4 +78,5 @@ class Navigation_Controller extends Abstract_Controller {
 
 		return Menu::menu( $this->nav_menu_args );
 	}
+
 }

--- a/wp-content/themes/core/components/navigation/index.js
+++ b/wp-content/themes/core/components/navigation/index.js
@@ -1,0 +1,12 @@
+/* -----------------------------------------------------------------------------
+ *
+ * Component: Navigation Menu
+ *
+ * This file is just a clearing-house, see the css directory
+ * and edit the source files found there.
+ *
+ * ----------------------------------------------------------------------------- */
+
+const init = () => {};
+
+export default init;

--- a/wp-content/themes/core/components/navigation/index.pcss
+++ b/wp-content/themes/core/components/navigation/index.pcss
@@ -1,0 +1,8 @@
+/* -----------------------------------------------------------------------------
+ *
+ * Component: Navigation Menu
+ *
+ * This file is just a clearing-house, see the css directory
+ * and edit the source files found there.
+ *
+ * ----------------------------------------------------------------------------- */

--- a/wp-content/themes/core/components/navigation/navigation.php
+++ b/wp-content/themes/core/components/navigation/navigation.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 use \Tribe\Project\Templates\Components\navigation\Navigation_Controller;
 

--- a/wp-content/themes/core/components/navigation/navigation.php
+++ b/wp-content/themes/core/components/navigation/navigation.php
@@ -1,0 +1,21 @@
+<?php declare( strict_types=1 );
+
+use \Tribe\Project\Templates\Components\navigation\Navigation_Controller;
+
+/**
+ * @var array $args Arguments passed to the template
+ */
+// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$c = Navigation_Controller::factory( $args );
+
+if ( ! $c->has_menu() ) {
+	return;
+}
+
+?>
+<nav <?php echo $c->get_classes(); ?> <?php echo $c->get_attrs(); ?>>
+	<ol <?php echo $c->get_nav_list_classes(); ?>>
+		<?php echo $c->get_menu(); ?>
+	</ol>
+</nav>
+


### PR DESCRIPTION
## What does this do/fix?
Adds a generic navigation menu component to SquareOne. This component will be used to disassociate the nav menu implementation from the context it appears in (masthead/footer/legal, etc). In future PRs I'll apply this component to SquareOne's menu locations.

[SQONE-521]
[SQONE-519]

[SQONE-521]: https://moderntribe.atlassian.net/browse/SQONE-521
[SQONE-519]: https://moderntribe.atlassian.net/browse/SQONE-519