### PR TITLE
SQONE-667: 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2021.09
+* Fixed: Style guide typography regression caused by Core's reset.css enqueuing in the block editor with the v5.8.0 release of WordPress.
 * Updated: ci GitHub action to allow manual runs
 * Fixed: Replace deleted repo https://github.com/hautelook/phpass with https://github.com/bordoni/phpass
 * Updated: wp-browser to 3.0.9

--- a/wp-content/plugins/core/src/Assets/Admin/Styles.php
+++ b/wp-content/plugins/core/src/Assets/Admin/Styles.php
@@ -59,7 +59,7 @@ class Styles {
 	 * @action admin_enqueue_scripts
 	 */
 	public function remove_editor_style_reset(): void {
-		if ( ! isset( wp_styles()->registered['wp-edit-blocks'] ) ) {
+		if ( ! isset( wp_styles()->registered['wp-edit-blocks']->deps ) ) {
 			return;
 		}
 

--- a/wp-content/plugins/core/src/Assets/Admin/Styles.php
+++ b/wp-content/plugins/core/src/Assets/Admin/Styles.php
@@ -54,7 +54,7 @@ class Styles {
 	 * This function may well be able to removed when the block editor is fully iframed
 	 * per the Gutenberg issue discussion linked below.
 	 *
-	 * See https://github.com/WordPress/gutenberg/pull/33522 for context.
+	 * @link https://github.com/WordPress/gutenberg/pull/33522 for context.
 	 *
 	 * @action admin_enqueue_scripts
 	 */

--- a/wp-content/plugins/core/src/Assets/Admin/Styles.php
+++ b/wp-content/plugins/core/src/Assets/Admin/Styles.php
@@ -43,4 +43,28 @@ class Styles {
 		wp_enqueue_style( 'tribe-styles-login' );
 	}
 
+	/**
+	 * This function removes the `wp-reset-editor-styles` style dependency from the
+	 * block editor styles enqueue.
+	 *
+	 * The Block Editor in WP Core v5.8.0 is enqueuing a reset.css file which overrides
+	 * many of our baseline typographic styles for paragraphs, headings, etc. due to the
+	 * specificity applied inside the `.editor-styles-wrapper` class.
+	 *
+	 * This function may well be able to removed when the block editor is fully iframed
+	 * per the Gutenberg issue discussion linked below.
+	 *
+	 * See https://github.com/WordPress/gutenberg/pull/33522 for context.
+	 *
+	 * @action admin_enqueue_scripts
+	 */
+	public function remove_editor_style_reset(): void {
+		if ( ! isset( wp_styles()->registered['wp-edit-blocks'] ) ) {
+			return;
+		}
+
+		$wp_edit_blocks_dependencies                    = array_diff( wp_styles()->registered['wp-edit-blocks']->deps, [ 'wp-reset-editor-styles' ] );
+		wp_styles()->registered['wp-edit-blocks']->deps = $wp_edit_blocks_dependencies;
+	}
+
 }

--- a/wp-content/plugins/core/src/Assets/Assets_Subscriber.php
+++ b/wp-content/plugins/core/src/Assets/Assets_Subscriber.php
@@ -71,6 +71,7 @@ class Assets_Subscriber extends Abstract_Subscriber {
 		add_action( 'admin_init', function () {
 			$this->container->get( Admin\Scripts::class )->register_scripts();
 			$this->container->get( Admin\Styles::class )->register_styles();
+			$this->container->get( Admin\Styles::class )->remove_editor_style_reset();
 		}, 10, 0 );
 
 


### PR DESCRIPTION
Bugfix for editor styles regression due to reset.css enqueued in the block editor in version 5.8 of WordPress Core.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/SQONE-667)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a bugfix applied to WP Core.
- [ ] No, I need help figuring out how to write the tests.

