### PR TITLE
Feature/block editor sliders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2021.11
+* Added: Entrypoint for component scripts to run in the block editor.
+* Added: Slider component JS behaviors in the block editor.
+
 ## 2021.10
 * Fixed: Misc small repairs to common blocks per QA on other projects.
 

--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -29,6 +29,13 @@ define( 'WP_ENVIRONMENT_TYPE', 'development' );
 define( 'HMR_DEV', false );
 
 /*
+ * Theme service worker
+ * 
+ * If your project needs to make use of the theme service worker, enable it here.
+ */
+// define( 'ENABLE_THEME_SERVICE_WORKER', true );
+
+/*
  * Panels
  *
  * If your project uses panels this will disable/enable panels caching.

--- a/wp-content/plugins/core/src/Assets/Admin/JS_Config.php
+++ b/wp-content/plugins/core/src/Assets/Admin/JS_Config.php
@@ -9,9 +9,8 @@ class JS_Config {
 	public function get_data() {
 		if ( ! isset( $this->data ) ) {
 			$this->data = [
-				'images_url'                 => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/admin/',
-				'block_denylist'             => apply_filters( 'tribe/project/blocks/denylist', [] ),
-				'block_theme_service_worker' => defined( 'BLOCK_THEME_SERVICE_WORKER' ) && BLOCK_THEME_SERVICE_WORKER === true,
+				'images_url'     => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/admin/',
+				'block_denylist' => apply_filters( 'tribe/project/blocks/denylist', [] ),
 			];
 			$this->data = apply_filters( 'core_admin_js_config', $this->data );
 		}

--- a/wp-content/plugins/core/src/Assets/Admin/JS_Config.php
+++ b/wp-content/plugins/core/src/Assets/Admin/JS_Config.php
@@ -9,8 +9,9 @@ class JS_Config {
 	public function get_data() {
 		if ( ! isset( $this->data ) ) {
 			$this->data = [
-				'images_url'     => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/admin/',
-				'block_denylist' => apply_filters( 'tribe/project/blocks/denylist', [] ),
+				'images_url'                 => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/admin/',
+				'block_denylist'             => apply_filters( 'tribe/project/blocks/denylist', [] ),
+				'block_theme_service_worker' => defined( 'BLOCK_THEME_SERVICE_WORKER' ) && BLOCK_THEME_SERVICE_WORKER === true,
 			];
 			$this->data = apply_filters( 'core_admin_js_config', $this->data );
 		}

--- a/wp-content/plugins/core/src/Assets/Theme/JS_Config.php
+++ b/wp-content/plugins/core/src/Assets/Theme/JS_Config.php
@@ -9,11 +9,11 @@ class JS_Config {
 	public function get_data() {
 		if ( ! isset( $this->data ) ) {
 			$this->data = [
-				'images_url'                 => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/theme',
-				'template_url'               => trailingslashit( get_template_directory_uri() ),
-				'script_debug'               => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG === true,
-				'hmr_dev'                    => defined( 'HMR_DEV' ) && HMR_DEV === true,
-				'block_theme_service_worker' => defined( 'BLOCK_THEME_SERVICE_WORKER' ) && BLOCK_THEME_SERVICE_WORKER === true,
+				'images_url'                  => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/theme',
+				'template_url'                => trailingslashit( get_template_directory_uri() ),
+				'script_debug'                => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG === true,
+				'hmr_dev'                     => defined( 'HMR_DEV' ) && HMR_DEV === true,
+				'enable_theme_service_worker' => defined( 'ENABLE_THEME_SERVICE_WORKER' ) && ENABLE_THEME_SERVICE_WORKER === true,
 			];
 			$this->data = apply_filters( 'core_js_config', $this->data );
 		}

--- a/wp-content/themes/core/assets/js/src/admin/editor/components.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/components.js
@@ -4,14 +4,10 @@
  * @description Initializes theme component JS in the block editor context.
  */
 
-import * as tests from 'utils/tests';
 import * as tools from 'utils/tools';
 
 const init = () => {
-	// Note that initializing sliders in the block editor is incompatible with
-	// service workers because it requires data that's not available in the
-	// editor.
-	if ( ! tests.supportsWorkers() && tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
+	if ( tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
 		import( 'components/slider' /* webpackChunkName:"editor-slider" */ ).then( ( module ) => {
 			module.default();
 		} );

--- a/wp-content/themes/core/assets/js/src/admin/editor/components.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/components.js
@@ -1,0 +1,14 @@
+/**
+ * @module
+ * @exports init
+ * @description Initializes theme component JS in the block editor context.
+ */
+
+import slider from 'components/slider';
+
+const init = () => {
+  slider();
+  console.info( 'SquareOne Admin: Initialized all components.' );
+};
+
+export default init;

--- a/wp-content/themes/core/assets/js/src/admin/editor/components.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/components.js
@@ -7,8 +7,8 @@
 import slider from 'components/slider';
 
 const init = () => {
-  slider();
-  console.info( 'SquareOne Admin: Initialized all components.' );
+	slider();
+	console.info( 'SquareOne Admin: Initialized all components.' );
 };
 
 export default init;

--- a/wp-content/themes/core/assets/js/src/admin/editor/components.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/components.js
@@ -11,7 +11,7 @@ const init = () => {
 	// Note that initializing sliders in the block editor is incompatible with
 	// service workers because it requires data that's not available in the
 	// editor.
-	if ( ! tests.supportsWorkers && tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
+	if ( ! tests.supportsWorkers() && tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
 		import( 'components/slider' /* webpackChunkName:"editor-slider" */ ).then( ( module ) => {
 			module.default();
 		} );

--- a/wp-content/themes/core/assets/js/src/admin/editor/components.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/components.js
@@ -4,10 +4,15 @@
  * @description Initializes theme component JS in the block editor context.
  */
 
-import slider from 'components/slider';
+import * as tools from 'utils/tools';
 
 const init = () => {
-	slider();
+	if ( tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
+		import( 'components/slider' /* webpackChunkName:"editor-slider" */ ).then( ( module ) => {
+			module.default();
+		} );
+	}
+
 	console.info( 'SquareOne Admin: Initialized all components.' );
 };
 

--- a/wp-content/themes/core/assets/js/src/admin/editor/components.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/components.js
@@ -11,7 +11,7 @@ const init = () => {
 	// Note that initializing sliders in the block editor is incompatible with
 	// service workers because it requires data that's not available in the
 	// editor.
-	if ( !tests.supportsWorkers && tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
+	if ( ! tests.supportsWorkers && tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
 		import( 'components/slider' /* webpackChunkName:"editor-slider" */ ).then( ( module ) => {
 			module.default();
 		} );

--- a/wp-content/themes/core/assets/js/src/admin/editor/components.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/components.js
@@ -4,10 +4,14 @@
  * @description Initializes theme component JS in the block editor context.
  */
 
+import * as tests from 'utils/tests';
 import * as tools from 'utils/tools';
 
 const init = () => {
-	if ( tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
+	// Note that initializing sliders in the block editor is incompatible with
+	// service workers because it requires data that's not available in the
+	// editor.
+	if ( !tests.supportsWorkers && tools.getNodes( '[data-js="c-slider"]', false, document, true )[ 0 ] ) {
 		import( 'components/slider' /* webpackChunkName:"editor-slider" */ ).then( ( module ) => {
 			module.default();
 		} );

--- a/wp-content/themes/core/assets/js/src/admin/editor/preview.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/preview.js
@@ -3,6 +3,7 @@ import 'lazysizes/plugins/object-fit/ls.object-fit';
 import 'lazysizes/plugins/parent-fit/ls.parent-fit';
 import 'lazysizes/plugins/respimg/ls.respimg';
 import 'lazysizes/plugins/bgset/ls.bgset';
+import components from './components';
 
 /**
  * @function appendSinkCssClasses
@@ -23,6 +24,7 @@ const appendSinkCssClasses = () => {
 
 const init = () => {
 	appendSinkCssClasses();
+	components();
 
 	console.info( 'SquareOne Admin: Initialized scripts needed for the editor preview.' );
 };

--- a/wp-content/themes/core/assets/js/src/theme/config/wp-settings.js
+++ b/wp-content/themes/core/assets/js/src/theme/config/wp-settings.js
@@ -1,5 +1,6 @@
-
-const wp = window.modern_tribe_config;
+// It's possible our context is the block editor in the admin theme, so fall
+// back to that config.
+const wp = window.modern_tribe_config || window.modern_tribe_admin_config || {};
 
 export const IMAGES_URL = wp.images_url;
 export const TEMPLATE_URL = wp.template_url;

--- a/wp-content/themes/core/assets/js/src/theme/config/wp-settings.js
+++ b/wp-content/themes/core/assets/js/src/theme/config/wp-settings.js
@@ -5,5 +5,5 @@ const wp = window.modern_tribe_config || window.modern_tribe_admin_config || {};
 export const IMAGES_URL = wp.images_url;
 export const TEMPLATE_URL = wp.template_url;
 export const HMR_DEV = wp.hmr_dev || 0;
-export const BLOCK_THEME_SERVICE_WORKER = wp.block_theme_service_worker || false;
+export const ENABLE_THEME_SERVICE_WORKER = wp.enable_theme_service_worker || false;
 export const SCRIPT_DEBUG = wp.script_debug || 0;

--- a/wp-content/themes/core/assets/js/src/utils/tests.js
+++ b/wp-content/themes/core/assets/js/src/utils/tests.js
@@ -1,5 +1,4 @@
-// @TODO: Allow this to be optional somehow?
-// import { BLOCK_THEME_SERVICE_WORKER } from 'config/wp-settings';
+import { BLOCK_THEME_SERVICE_WORKER } from 'config/wp-settings';
 
 /**
  * @module
@@ -46,8 +45,7 @@ const isElementHidden = ( el ) => {
  */
 
 // @TODO: Make this degrade with optional service worker support.
-// const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! BLOCK_THEME_SERVICE_WORKER );
-const supportsWorkers = false;
+const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! BLOCK_THEME_SERVICE_WORKER );
 
 const android = /(android)/i.test( navigator.userAgent );
 const chrome = !! window.chrome;

--- a/wp-content/themes/core/assets/js/src/utils/tests.js
+++ b/wp-content/themes/core/assets/js/src/utils/tests.js
@@ -43,8 +43,6 @@ const isElementHidden = ( el ) => {
  * @function supportsWorkers
  * @description Checks for both service worker support and indexedDb support, plus also checks if we want them loaded with a passed php constant messaged to js through our js config
  */
-
-// @TODO: Make this degrade with optional service worker support.
 const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! BLOCK_THEME_SERVICE_WORKER );
 
 const android = /(android)/i.test( navigator.userAgent );

--- a/wp-content/themes/core/assets/js/src/utils/tests.js
+++ b/wp-content/themes/core/assets/js/src/utils/tests.js
@@ -43,6 +43,7 @@ const isElementHidden = ( el ) => {
  * @function supportsWorkers
  * @description Checks for both service worker support and indexedDb support, plus also checks if we want them loaded with a passed php constant messaged to js through our js config
  */
+
 const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! BLOCK_THEME_SERVICE_WORKER );
 
 const android = /(android)/i.test( navigator.userAgent );

--- a/wp-content/themes/core/assets/js/src/utils/tests.js
+++ b/wp-content/themes/core/assets/js/src/utils/tests.js
@@ -44,7 +44,7 @@ const isElementHidden = ( el ) => {
  * @description Checks for both service worker support and indexedDb support, plus also checks if we want them loaded with a passed php constant messaged to js through our js config
  */
 
-const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! ENABLE_THEME_SERVICE_WORKER );
+const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ENABLE_THEME_SERVICE_WORKER );
 
 const android = /(android)/i.test( navigator.userAgent );
 const chrome = !! window.chrome;

--- a/wp-content/themes/core/assets/js/src/utils/tests.js
+++ b/wp-content/themes/core/assets/js/src/utils/tests.js
@@ -1,4 +1,5 @@
-import { BLOCK_THEME_SERVICE_WORKER } from 'config/wp-settings';
+// @TODO: Allow this to be optional somehow?
+// import { BLOCK_THEME_SERVICE_WORKER } from 'config/wp-settings';
 
 /**
  * @module
@@ -44,7 +45,9 @@ const isElementHidden = ( el ) => {
  * @description Checks for both service worker support and indexedDb support, plus also checks if we want them loaded with a passed php constant messaged to js through our js config
  */
 
-const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! BLOCK_THEME_SERVICE_WORKER );
+// @TODO: Make this degrade with optional service worker support.
+// const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! BLOCK_THEME_SERVICE_WORKER );
+const supportsWorkers = false;
 
 const android = /(android)/i.test( navigator.userAgent );
 const chrome = !! window.chrome;

--- a/wp-content/themes/core/assets/js/src/utils/tests.js
+++ b/wp-content/themes/core/assets/js/src/utils/tests.js
@@ -1,4 +1,4 @@
-import { BLOCK_THEME_SERVICE_WORKER } from 'config/wp-settings';
+import { ENABLE_THEME_SERVICE_WORKER } from 'config/wp-settings';
 
 /**
  * @module
@@ -44,7 +44,7 @@ const isElementHidden = ( el ) => {
  * @description Checks for both service worker support and indexedDb support, plus also checks if we want them loaded with a passed php constant messaged to js through our js config
  */
 
-const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! BLOCK_THEME_SERVICE_WORKER );
+const supportsWorkers = () => ( 'serviceWorker' in navigator && 'indexedDB' in window && ! ENABLE_THEME_SERVICE_WORKER );
 
 const android = /(android)/i.test( navigator.userAgent );
 const chrome = !! window.chrome;

--- a/wp-content/themes/core/components/blocks/_css/block-editor.pcss
+++ b/wp-content/themes/core/components/blocks/_css/block-editor.pcss
@@ -26,9 +26,9 @@
 
 .wp-block[data-type="acf/galleryslider"] {
 	/* CASE: Fixed image ratio gallery slider */
-	.b-gallery-slider--fixed {
+	.b-gallery-slider--fixed:not(.initialized) {
 
-		.c-slider__wrapper {
+		> .c-slider__wrapper {
 			justify-content: center;
 			transform: translate3d(0, 0, 0);
 			overflow-x: hidden;

--- a/wp-content/themes/core/components/slider/js/slider.js
+++ b/wp-content/themes/core/components/slider/js/slider.js
@@ -112,7 +112,7 @@ const focusRow = ( index, rowIndex, jumpTo ) => {
 
 /**
  * @module
- * @description Swiper init.
+ * @description Swiper init. Make sure to keep this idempotent/safe to call multiple times!
  */
 
 const initSliders = () => {
@@ -157,8 +157,8 @@ const previewChangeHandler = ( e ) => {
 };
 
 const test = ( what ) => {
-	console.log('test', what);
-}
+	console.log( 'test', what );
+};
 
 /**
  * @module
@@ -171,9 +171,7 @@ const bindEvents = () => {
 	document.addEventListener( 'modular_content/repeater_row_deactivated', previewChangeHandler );
 	document.addEventListener( 'modular_content/repeater_row_added', previewChangeHandler );
 	if ( window.acf ) {
-		console.log('bound to acf render_block_preview');
-		// window.acf.addAction( 'render_block_preview', previewChangeHandler );
-		window.acf.addAction( 'render_block_preview', test );
+		window.acf.addAction( 'render_block_preview', initSliders );
 	}
 	document.addEventListener( 'modern_tribe/component_dialog_rendered', initSliders );
 };

--- a/wp-content/themes/core/components/slider/js/slider.js
+++ b/wp-content/themes/core/components/slider/js/slider.js
@@ -21,6 +21,8 @@ const options = {
 		a11y: {
 			enabled: true,
 		},
+		watchSlidesVisibility: true,
+		watchOverflow: true,
 	} ),
 	swiperThumbs: () => ( {
 		a11y: {
@@ -154,6 +156,10 @@ const previewChangeHandler = ( e ) => {
 	}, 50 );
 };
 
+const test = ( what ) => {
+	console.log('test', what);
+}
+
 /**
  * @module
  * @description Bind Events.
@@ -164,6 +170,11 @@ const bindEvents = () => {
 	document.addEventListener( 'modular_content/repeater_row_activated', previewChangeHandler );
 	document.addEventListener( 'modular_content/repeater_row_deactivated', previewChangeHandler );
 	document.addEventListener( 'modular_content/repeater_row_added', previewChangeHandler );
+	if ( window.acf ) {
+		console.log('bound to acf render_block_preview');
+		// window.acf.addAction( 'render_block_preview', previewChangeHandler );
+		window.acf.addAction( 'render_block_preview', test );
+	}
 	document.addEventListener( 'modern_tribe/component_dialog_rendered', initSliders );
 };
 

--- a/wp-content/themes/core/components/slider/js/slider.js
+++ b/wp-content/themes/core/components/slider/js/slider.js
@@ -156,10 +156,6 @@ const previewChangeHandler = ( e ) => {
 	}, 50 );
 };
 
-const test = ( what ) => {
-	console.log( 'test', what );
-};
-
 /**
  * @module
  * @description Bind Events.


### PR DESCRIPTION
## What does this do/fix?

Adds optional support for component JS in the block editor (`BLOCK_THEME_SERVICE_WORKER` must be off/disabled). 
Once enabled, component scripts may be enabled in the block editor via `wp-content/themes/core/assets/js/src/admin/editor/components.js`.

This PR also updates the slider component to be compatible with this change. When service workers have been disabled, slider components should be automatically initialized in the block editor, and properly re-initialized when the block preview is updated.


## QA

Links to relevant issues
- [SQONE-578](https://moderntribe.atlassian.net/browse/SQONE-578?atlOrigin=eyJpIjoiMzI1NmE2ZWM0M2QyNDU3Yjg3YjQxN2E1OTAzMzk0YjQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
- [Vinny's OG Slack thread](https://tribe.slack.com/archives/C01CY7418GY/p1635432487119600)
- [Brett's secondary Slack thread](https://tribe.slack.com/archives/C01CY7418GY/p1636044666192800)
- [Helpful related commit from Antonio](https://github.com/moderntribe/harvard-flagship/commit/3b4e4029728371f7f42782aa306fd5dd2aad9f29)

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

