### PR TITLE
Bugfix/jira ticket prefixing

### DIFF
--- a/.lefthook/prepare-commit-msg/prefix_with_jira_ticket
+++ b/.lefthook/prepare-commit-msg/prefix_with_jira_ticket
@@ -7,8 +7,11 @@
 FILE=$1
 MESSAGE=$(cat $FILE)
 IFS=/ read -a parts <<< $(git rev-parse --abbrev-ref HEAD)
+
+IS_SPECIAL_BRANCH=$(echo ${parts[0]} | grep -i 'release/\|sprint/')
+[[ ! -z "$IS_SPECIAL_BRANCH" ]] || exit 0
+
 TICKET=[$(echo ${parts[1]} | grep -Eo '(\w+[-])?[0-9]+')]
-if [[ $TICKET == "[]" || "$MESSAGE" == "$TICKET"* ]]; then
-  exit 0
-fi
+[[ $TICKET == "[]" || "$MESSAGE" == "$TICKET"* ]] || exit 0
+
 echo "$TICKET $MESSAGE" > $FILE

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2021.11
+* Fixed: Lefthook - Don't prefix commits for sprint or release branches
 * Updated: docker image to 74-3.0, composer v2 support (requires `so` v5.3.0+)
 * Added: Entrypoint for component scripts to run in the block editor.
 * Added: Slider component JS behaviors in the block editor.


### PR DESCRIPTION
## What does this do/fix?

- Fixes bad prefixed commits when using sprint or release branches that contain numbers after them.

## QA

- You should not get any prefixing when committing a branch like `release/21.11.01` or `sprint/21.01`
- Branches such as `feature/XXX-21/my-feature` should still properly get prefixed with `[XXX-21]: original commit...`

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a lefthook update.
- [ ] No, I need help figuring out how to write the tests.

