### PR TITLE
Apply nav menu classes only if `theme_location` parameter is populated

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 * Updated: docker image to 74-3.0, composer v2 support (requires `so` v5.3.0+)
 * Added: Entrypoint for component scripts to run in the block editor.
 * Added: Slider component JS behaviors in the block editor.
+* Added: check that `theme_location` parameter of `wp_nav_menu()` is populated before adding classes
  
 ## 2021.10
 * Fixed: Misc small repairs to common blocks per QA on other projects.

--- a/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
@@ -42,6 +42,10 @@ class Nav_Attribute_Filters {
 	 * @filter nav_menu_css_class
 	 */
 	public function customize_nav_item_classes( array $classes, object $item, stdClass $args, int $depth ): array {
+		if ( empty( $args->theme_location ) ) {
+			return $classes;
+		}
+
 		$theme_location = $args->theme_location;
 
 		$classes[] = $theme_location . '__list-item';
@@ -105,6 +109,10 @@ class Nav_Attribute_Filters {
 	 * @filter nav_menu_link_attributes
 	 */
 	public function customize_nav_item_anchor_atts( array $atts, object $item, stdClass $args, int $depth ): array {
+		if ( empty( $args->theme_location ) ) {
+			return $atts;
+		}
+
 		$theme_location = $args->theme_location;
 
 		$classes = [

--- a/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Nav_Attribute_Filters.php
@@ -12,61 +12,6 @@ use stdClass;
 class Nav_Attribute_Filters {
 
 	/**
-	 * Generate a class prefix based on wp_nav_menu() parameters.
-	 *
-	 * Because `menu` overrides `theme_location`, and `theme_location` is used if
-	 * `menu` is empty or menu does not exist, the solution is to get the slugs
-	 * of both menus, and if they're equal, use the theme location. If they're not equal,
-	 * then use the menu slug.
-	 *
-	 * @param stdClass $args An object of {@see wp_nav_menu()} arguments.
-	 *
-	 * @return string
-	 *
-	 * @todo evaluate: prepending "location-" and "menu-" is backwards-compatibility issue
-	 */
-	protected function get_class_prefix( stdClass $args ): string {
-		$menu = wp_get_nav_menu_object( $args->menu );
-		$locations = get_nav_menu_locations();
-
-		$menu_slug = '';
-		$location_menu_slug = '';
-
-		// Get slug of menu if exists.
-		if ( $menu ) {
-			$menu_slug = $menu->slug;
-		}
-
-		// Get theme location's menu.
-		if ( $args->theme_location && $locations && isset( $locations[ $args->theme_location ] ) ) {
-			$location_menu = wp_get_nav_menu_object( $locations[ $args->theme_location ] );
-		}
-
-		// Get theme location's menu's slug.
-		if ( ! empty( $location_menu ) ) {
-			$location_menu_slug = $location_menu->slug;
-		}
-
-		// Both slugs are empty, we've got nothing: bail.
-		if ( ! $menu_slug && ! $location_menu_slug ) {
-			return '';
-		}
-
-		// Menu and location menu slug are equal: use theme location.
-		if ( $menu_slug === $location_menu_slug ) {
-			return 'location-' . $args->theme_location;
-		}
-
-		// Menu slug is empty and theme location is specified: use theme location.
-		if ( ! $menu_slug && $args->theme_location ) {
-			return 'location-' . $args->theme_location;
-		}
-
-		// Must be a specified menu.
-		return 'menu-' . $menu_slug;
-	}
-
-	/**
 	 * Remove the ID attributed from the nav item
 	 *
 	 * @param string    $menu_id The ID that is applied to the menu item's `<li>` element.
@@ -97,30 +42,26 @@ class Nav_Attribute_Filters {
 	 * @filter nav_menu_css_class
 	 */
 	public function customize_nav_item_classes( array $classes, object $item, stdClass $args, int $depth ): array {
-		$class_prefix = $this->get_class_prefix( $args );
+		$theme_location = $args->theme_location;
 
-		if ( empty( $class_prefix ) ) {
-			return $classes;
-		}
-
-		$classes[] = $class_prefix . '__list-item';
+		$classes[] = $theme_location . '__list-item';
 
 		// Depth
-		$classes[] = $class_prefix . '__list-item--depth-' . $depth;
+		$classes[] = $theme_location . '__list-item--depth-' . $depth;
 
 		// Has children items
 		if ( in_array( 'menu-item-has-children', $item->classes ) ) {
-			$classes[] = $class_prefix . '__list-item--has-children';
+			$classes[] = $theme_location . '__list-item--has-children';
 		}
 
 		// Is Parent Item
 		if ( in_array( 'current-menu-parent', $item->classes ) ) {
-			$classes[] = $class_prefix . '__list-item--is-current-parent';
+			$classes[] = $theme_location . '__list-item--is-current-parent';
 		}
 
 		// Is Current Item
 		if ( in_array( 'current-menu-item', $item->classes ) ) {
-			$classes[] = $class_prefix . '__list-item--is-current';
+			$classes[] = $theme_location . '__list-item--is-current';
 		}
 
 		/**
@@ -164,20 +105,16 @@ class Nav_Attribute_Filters {
 	 * @filter nav_menu_link_attributes
 	 */
 	public function customize_nav_item_anchor_atts( array $atts, object $item, stdClass $args, int $depth ): array {
-		$class_prefix = $this->get_class_prefix( $args );
-
-		if ( empty( $class_prefix ) ) {
-			return $atts;
-		}
+		$theme_location = $args->theme_location;
 
 		$classes = [
-			$class_prefix . '__action',
-			$class_prefix . '__action--depth-' . $depth,
+			$theme_location . '__action',
+			$theme_location . '__action--depth-' . $depth,
 		];
 
 		// Has children items
 		if ( in_array( 'menu-item-has-children', $item->classes ) ) {
-			$classes[] = $class_prefix . '__action--has-children';
+			$classes[] = $theme_location . '__action--has-children';
 		}
 
 		$atts['class'] = implode( ' ', array_unique( $classes ) );


### PR DESCRIPTION
## What does this do/fix?

Improves the classes added to nav menu elements by supporting the `menu` parameter (of `wp_nav_menu()`). See #880.

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

After creating two menus (`sample` and `primary`) and assigning one of them to the `primary` theme location, added the following code to an mu-plugin to easily test the proper output:

```php
<?php declare(strict_types=1);

use Tribe\Project\Nav_Menus\Menu;

add_action( 'wp_body_open', function() {

	// Test theme_location parameter.
	echo Menu::menu( [
		'theme_location' => 'primary',
		'container_class' => 'test-1 location-primary',
	] );

	// Test menu parameter.
	echo Menu::menu( [
		'menu' => 'sample',
		'container_class' => 'test-2 menu-sample',
	] );

	// Test menu and theme_location parameter.
	echo Menu::menu( [
		'menu' => 'sample',
		'theme_location' => 'primary',
		'container_class' => 'test-3 menu-sample',
	] );

	// Test invalid menu and valid theme_location parameter.
	echo Menu::menu( [
		'menu' => 'foo',
		'theme_location' => 'primary',
		'container_class' => 'test-4 location-primary',
	] );

	// Test valid menu and invalid theme_location parameter.
	echo Menu::menu( [
		'menu' => 'sample',
		'theme_location' => 'bar',
		'container_class' => 'test-5 menu-sample',
	] );

	exit;
} );
```

