### PR TITLE
SQONE-683 Rollback mini-css-extract version update due to breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "jest-environment-jsdom": "^24.9.0",
     "jest-environment-jsdom-global": "^1.2.0",
     "json2php": "0.0.4",
-    "mini-css-extract-plugin": "^2.4.5",
+    "mini-css-extract-plugin": "^0.9.0",
     "postcss-aspect-ratio": "^1.0.0",
     "postcss-assets": "^5.0.0",
     "postcss-calc": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9737,12 +9737,15 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-mini-css-extract-plugin@^2.4.5:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.5.tgz#191d6c170226037212c483af1180b4010b7b9eef"
-  integrity sha512-oEIhRucyn1JbT/1tU2BhnwO6ft1jjH1iCX9Gc59WFMg0n5773rQU0oyQ0zzeYFFuBfONaRbQJyGoPtuNseMxjA==
+mini-css-extract-plugin@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz#47f2cf07aa165ab35733b1fc97d4c46c0564339e"
+  integrity sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==
   dependencies:
-    schema-utils "^4.0.0"
+    loader-utils "^1.1.0"
+    normalize-url "1.9.1"
+    schema-utils "^1.0.0"
+    webpack-sources "^1.1.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -10079,7 +10082,7 @@ normalize-selector@^0.2.0:
   resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
   integrity sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=
 
-normalize-url@^1.4.0, normalize-url@^1.9.1:
+normalize-url@1.9.1, normalize-url@^1.4.0, normalize-url@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
   integrity sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=
@@ -15564,7 +15567,7 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==


### PR DESCRIPTION
## What does this do/fix?
Rolls back the version of one webpack dependency due to the update breaking the watch task:
```[09:20:07] Using gulpfile ~/Projects/squareone/htdocs/gulpfile.js
[09:20:07] Starting 'dev'...
[09:20:07] Starting 'watch:frontEndDev'...
[09:20:07] Starting 'watch:watchAdminJS'...
[09:20:07] Starting 'watch:watchThemeJS'...
[09:20:07] Starting '<anonymous>'...
[09:20:07] 'watch:watchAdminJS' errored after 143 ms
[09:20:07] TypeError: Invalid value used in weak set
    at WeakSet.add (<anonymous>:null:null)
    at MiniCssExtractPlugin.apply (/home/dpe/Projects/squareone/htdocs/node_modules/mini-css-extract-plugin/dist/index.js:385:18)
    at webpack (/home/dpe/Projects/squareone/htdocs/node_modules/webpack-stream/node_modules/webpack/lib/webpack.js:51:13)
    at Stream.<anonymous> (/home/dpe/Projects/squareone/htdocs/node_modules/webpack-stream/index.js:151:38)
    at _end (/home/dpe/Projects/squareone/htdocs/node_modules/through/index.js:65:9)
    at Stream.stream.end (/home/dpe/Projects/squareone/htdocs/node_modules/through/index.js:74:5)
    at module.exports (/home/dpe/Projects/squareone/htdocs/node_modules/webpack-stream/index.js:247:12)
    at watchAdminJS (/home/dpe/Projects/squareone/htdocs/gulp-tasks/watch.js:91:11)
    at taskWrapper (/home/dpe/Projects/squareone/htdocs/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (node:domain:421:15)
    at runBound (node:domain:432:12)
    at asyncRunner (/home/dpe/Projects/squareone/htdocs/node_modules/async-done/index.js:55:18)
    at processTicksAndRejections (node:internal/process/task_queues:78:11)

[09:20:07] 'dev' errored after 145 ms
```
