### PR TITLE
Add composer v2.2+ allowed plugins

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.01 
+* Updated: added allowed plugins to composer.json
 * Updated: coding standards to [version 2](https://github.com/moderntribe/coding-standards/tree/2.0.x).
 * Updated: WordPress 5.7.3 > 5.8.3 (security release)
 * Updated: ACF Pro 5.10.2 > 5.11.4

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,12 @@
     "sort-packages": true,
     "preferred-install": {
       "*": "dist"
+    },
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "composer/installers": true,
+      "ffraenz/private-composer-installer": true,
+      "johnpbloch/wordpress-core-installer": true
     }
   },
   "description": "Modern Tribe's Square One WordPress setup",


### PR DESCRIPTION
## What does this do/fix?

- [composer 2.2+](https://github.com/composer/composer/releases/tag/2.2.0) has added an `allow-plugins` configuration value, which then asks you if you want to allow each plugin in your composer.json. This adds our current plugin configuration. We could alternatively allow all plugins with `allow-plugins: true` as well. 

Projects that newly pull the `moderntribe/squareone-php7.4-3.0` image will be asked to add their plugins to their composer.json as well, and can do so once [so 5.5.1 bugfix](https://github.com/moderntribe/square1-global-docker/pull/102) is released.

## QA

Running `composer install` when using composer v2.2+ should no longer ask you if you want to enable these plugins and function as normal.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's an update based on an external dependency.
- [ ] No, I need help figuring out how to write the tests.

