### PR TITLE
Use correct secret/token for composer

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -56,7 +56,7 @@ jobs:
           extensions: ${{ env.php_extensions }}
           coverage: none
         env:
-          COMPOSER_TOKEN: ${{ secrets.token }}
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate composer.json and composer.lock
         if: ${{ steps.filter.outputs.wpcontent == 'true' }}

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.01 
+* Fixed: phpcs GitHub workflow using the wrong secret.
 * Added: An empty CLI_Definer to easier register commands.
 * Updated: added allowed plugins to composer.json
 * Updated: coding standards to [version 2](https://github.com/moderntribe/coding-standards/tree/2.0.x).


### PR DESCRIPTION
## What does this do/fix?

- Bad copy pasta of the composer token. Props @lindseyolson for pointing it out!

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a GitHub workflow update
- [ ] No, I need help figuring out how to write the tests.

