### PR TITLE
[SQONE-684] Swiper imagesReady event listener

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 * Updated: TEC 5.10.1 > 5.12.2
 * Updated: Yoast 17.5 > 17.8
 * Removed: Service Worker (PWA) support
+* Updated: Ensures Swiper.js `imagesReady` event listener is always added during initialization of a new Swiper instance.
 
 ## 2021.12
 * Fixed: docker compose (v2) support: `WARN[0000] network proxy: network.external.name is deprecated in favor of network.name`

--- a/wp-content/themes/core/components/blocks/gallery_slider/js/gallery-slider.js
+++ b/wp-content/themes/core/components/blocks/gallery_slider/js/gallery-slider.js
@@ -13,8 +13,8 @@ const gallerySliderBlocks = tools.getNodes( '.b-gallery-slider', true, document,
  * @description Set slide width on variable image ratio sliders to contain caption.
  */
 
-const setVariableSlideWidth = ( e ) => {
-	const slider = e.detail.slider.el;
+const setVariableSlideWidth = ( swiper ) => {
+	const slider = swiper.el;
 	if ( ! slider || ! slider.classList.contains( 'b-gallery-slider--variable' ) ) {
 		return;
 	}
@@ -25,7 +25,7 @@ const setVariableSlideWidth = ( e ) => {
 	} );
 
 	// Recalculate slide offsets
-	e.detail.slider.updateSlides();
+	swiper.updateSlides();
 };
 
 /**

--- a/wp-content/themes/core/components/slider/js/slider.js
+++ b/wp-content/themes/core/components/slider/js/slider.js
@@ -21,6 +21,28 @@ const options = {
 		a11y: {
 			enabled: true,
 		},
+		/**
+		 * Register Swiper.js event handlers
+		 * https://swiperjs.com/swiper-api#param-on
+		 *
+		 * Allows event handlers to be added upon swiper initialization.
+		 *
+		 * See all available events: https://swiperjs.com/swiper-api#events
+		 */
+		on: {
+			/**
+			 * Event will be fired right after all inner images are loaded.
+			 * Note that updateOnImagesReady parameter should be also enabled on
+			 * a Swiper instance to properly fire this event.
+			 */
+			imagesReady: ( swiper ) => {
+				trigger( {
+					event: 'modern_tribe/swiper_images_ready',
+					data: { swiper }, // passes the current swiper instance
+					native: false,
+				} );
+			},
+		},
 		watchSlidesVisibility: true,
 		watchOverflow: true,
 	} ),
@@ -122,13 +144,6 @@ const initSliders = () => {
 		instances.swipers[ swiperMainId ] = new SwiperCore( slider, getMainOptsForSlider( slider, swiperMainId ) );
 		slider.setAttribute( 'data-id', swiperMainId );
 		slider.setAttribute( 'id', swiperMainId );
-		instances.swipers[ swiperMainId ].on( 'imagesReady', () => {
-			trigger( {
-				event: 'modern_tribe/swiper_images_ready',
-				data: { slider: instances.swipers[ swiperMainId ] },
-				native: false,
-			} );
-		} );
 	} );
 };
 


### PR DESCRIPTION
## What does this do/fix?

In the slider component JS, the imagesReady event is added to the sliders after they have already been initialized. This leads to unpredictable triggering of the imagesReady event since in some cases, the slider images have already been loaded by the time the event is added.

This PR adds the event listener during initialization of a `Swiper` instance to ensure it is always triggered. It also updates the `modern_tribe/swiper_images_ready` custom event to pass the current swiper instance when that event is triggered, allowing easier access to the Swiper instance and all of its parameters and methods.

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

