### PR TITLE
[SQONE-644] Fix social share pop for multiple components

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 * Updated: Yoast 17.5 > 17.8
 * Removed: Service Worker (PWA) support
 * Updated: Ensures Swiper.js `imagesReady` event listener is always added during initialization of a new Swiper instance.
+* Fixed: Social share component now properly triggers popup when more than one component is present on a page.
 
 ## 2021.12
 * Fixed: docker compose (v2) support: `WARN[0000] network proxy: network.external.name is deprecated in favor of network.name`

--- a/wp-content/themes/core/components/share/js/share.js
+++ b/wp-content/themes/core/components/share/js/share.js
@@ -14,7 +14,7 @@ import * as tools from 'utils/tools';
 import popup from 'utils/dom/popup';
 
 const el = {
-	container: tools.getNodes( 'social-share-networks' )[ 0 ],
+	container: tools.getNodes( 'social-share-networks' ),
 };
 
 /**
@@ -48,7 +48,7 @@ const bindEvents = () => {
  */
 
 const socialShare = () => {
-	if ( ! el.container ) {
+	if ( el.container.length === 0 ) {
 		return;
 	}
 


### PR DESCRIPTION
## What does this do/fix?

The JS for the social-share component uses the first instance of itself as the container element. This prevents the JS events from being delegated to additional instances of the component (such as a single post with share icons in the header and footer). 

This PR allows for an indefinite number of social share components to be used on a page.

## QA

Links to deployed, scaffolded demo:
- [Link to Demo](https://sq1-pr.moderntribe.qa/post-49/)
