### PR TITLE
Reduce unnecessary JavaScript initialization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 * Updated: Yoast 17.5 > 17.8
 * Removed: Service Worker (PWA) support
 * Updated: Ensures Swiper.js `imagesReady` event listener is always added during initialization of a new Swiper instance.
+* Updated: Fixed several components whose JavaScript could initialize even when component isn't present on a page.
 
 ## 2021.12
 * Fixed: docker compose (v2) support: `WARN[0000] network proxy: network.external.name is deprecated in favor of network.name`

--- a/wp-content/themes/core/components/accordion/js/accordion.js
+++ b/wp-content/themes/core/components/accordion/js/accordion.js
@@ -18,6 +18,10 @@ import * as slide from 'utils/dom/slide';
 import * as tools from 'utils/tools';
 import * as events from 'utils/events';
 
+const el = {
+	container: tools.getNodes( 'c-accordion' ),
+};
+
 const siteWrap = tools.getNodes( 'site-wrap' )[ 0 ];
 const pn = document.getElementById( 'panel-navigation' );
 const options = {
@@ -160,6 +164,10 @@ const bindEvents = () => {
  */
 
 const init = () => {
+	if ( el.container.length === 0 ) {
+		return;
+	}
+
 	setOffset();
 	bindEvents();
 

--- a/wp-content/themes/core/components/blocks/gallery_slider/js/gallery-slider.js
+++ b/wp-content/themes/core/components/blocks/gallery_slider/js/gallery-slider.js
@@ -42,7 +42,7 @@ const bindEvents = () => {
  * @description Initialize if gallery slider blocks are on the page.
  */
 const init = () => {
-	if ( ! gallerySliderBlocks ) {
+	if ( gallerySliderBlocks.length === 0 ) {
 		return;
 	}
 

--- a/wp-content/themes/core/components/card/js/card.js
+++ b/wp-content/themes/core/components/card/js/card.js
@@ -7,6 +7,8 @@
  * ----------------------------------------------------------------------------- */
 
 import delegate from 'delegate';
+import * as tools from 'utils/tools';
+
 
 /* Maximum amount of time between mousedown & mouseup to be considered a true click */
 const MOUSEUP_THRESHOLD = 200;
@@ -16,6 +18,7 @@ const EXCLUDED_TARGETS = [ 'A', 'BUTTON' ];
 
 const el = {
 	siteWrap: document.querySelector( '[data-js="site-wrap"]' ),
+	container: tools.getNodes( 'c-card' ),
 };
 
 const state = {
@@ -86,6 +89,10 @@ const bindEvents = () => {
  * init
  */
 const init = () => {
+	if ( el.container.length === 0 ) {
+		return;
+	}
+
 	bindEvents();
 
 	console.info( 'SquareOne Theme: Initialized card component scripts.' );

--- a/wp-content/themes/core/components/tabs/js/tabs.js
+++ b/wp-content/themes/core/components/tabs/js/tabs.js
@@ -273,7 +273,7 @@ const cacheElements = () => {};
  * @description Initializes the class if the element(s) to work on are found.
  */
 const init = () => {
-	if ( ! el.tabsComponents ) {
+	if ( el.tabsComponents.length === 0 ) {
 		return;
 	}
 

--- a/wp-content/themes/core/integrations/gravity-forms/js/gravity-forms.js
+++ b/wp-content/themes/core/integrations/gravity-forms/js/gravity-forms.js
@@ -9,7 +9,7 @@ import * as tools from 'utils/tools';
 import scrollTo from 'utils/dom/scroll-to';
 
 const el = {
-	container: tools.getNodes( 'site-wrap' )[ 0 ],
+	container: tools.getNodes( '.gform_wrapper', false, document, true ),
 };
 
 let spinner;
@@ -93,7 +93,7 @@ const bindEvents = () => {
  */
 
 const gravityForms = () => {
-	if ( ! el.container ) {
+	if ( el.container.length === 0 ) {
 		return;
 	}
 


### PR DESCRIPTION
## What does this do/fix?

There are a number of components that are able to initialize their JavaScript even when the component is not present on a page. This PR updates those components so that any required JS is only loaded when necessary.

**Components Addressed:**
- Accordion
- Card
- Tabs
- Gallery Slider Block
- Gravity Forms


## QA

Links to deployed, scaffolded demo:
- [Link to Demo](http://sq1-pr.moderntribe.qa/)

Screenshots/video:
- [Console Log showing init of non-present components](http://p.tri.be/M4vc9o)

