### PR TITLE
Add proxy_ssl_server_name on; for nginx image proxy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2022.01 
+## 2022.01
+* Added: `proxy_ssl_server_name on;` in nginx.conf to allow proxying to production domains if they are using Cloudflare.
 * Fixed: phpcs GitHub workflow using the wrong secret.
 * Added: An empty CLI_Definer to easier register commands.
 * Updated: added allowed plugins to composer.json

--- a/dev/docker/nginx/nginx.conf
+++ b/dev/docker/nginx/nginx.conf
@@ -20,6 +20,7 @@ server {
     # Replace "https://livedomain.tld" with your production/dev URL to pull assets from another server.
     location @images {
         resolver 1.1.1.1;
+        proxy_ssl_server_name on;
         proxy_pass https://livedomain.tld/$uri;
     }
 


### PR DESCRIPTION
## What does this do/fix?

If your production host for proxying images is behind Cloudflare, the image proxy will fail without this addition to support SNI SSL certificates.

## QA

- A production domain configured in nginx.conf that is behind Cloudflare will now display images on your local environment.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's an nginx update.
- [ ] No, I need help figuring out how to write the tests.

