### PR TITLE
Add optimized opcache configuration

### DIFF
--- a/dev/docker/php/php-ini-overrides.ini
+++ b/dev/docker/php/php-ini-overrides.ini
@@ -8,6 +8,22 @@ error_log=/proc/1/fd/2
 upload_max_filesize=100M
 post_max_size=108M
 
+; opcache: https://www.php.net/manual/en/opcache.configuration.php
+opcache.revalidate_freq=2
+opcache.validate_timestamps=1
+
+; Increase these if your project has a lot of files
+opcache.max_accelerated_files=25000
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=16
+
+; These improve performance, but can cause issues.
+; Comment out if you experience strange behaviour.
+opcache.use_cwd=0
+opcache.enable_file_override=1
+opcache.file_update_protection=0
+opcache.file_cache=/tmp
+
 ; xdebug
 xdebug.idekey="PHPSTORM"
 xdebug.mode=debug,profile,trace


### PR DESCRIPTION
## What does this do/fix?

Improves container PHP performance. The default max accelerated files out of the box is `10000`, and a fresh square-one has `16388`.

Devs can run the following in their project to determine the amount of PHP files that exist, and adjust their project's default accordingly.

```bash
find . -type f -print | grep php | wc -l
```

## QA

I'd suggest you copy these into a (modern) project you're working on right now, do a `so stop; so start` and work as normal. Let us know in the comments if anything strange happens. I'm mostly curious for macOS users.

Specifically a bit concerned about this one on a mac: https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.file_update_protection

You can also dump https://www.php.net/manual/en/function.opcache-get-status.php to see some stats such.
## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because this is a php.ini change
- [ ] No, I need help figuring out how to write the tests.

