### PR TITLE
Bugfix for Jetpack sync fatal errors w/ force plugin activation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 * Changed: Replaced `msawicki/acf-menu-chooser` with a forked https://github.com/moderntribe/acf-menu-chooser that includes security fixes and is also added to packagist.
 * Updated: ACF (5.12), Tribe Libs (3.4.10), Redirection (5.2.3), Yoast (18.2), TEC (5.14.0.4)
 * Updated: Aligns accordion component with WAI-ARIA standard
+* Fixed: Jetpack sync calls the `all_plugins` filter outside of a screen context, causing fatal errors in our force plugin activation MU plugin when using multisite.
 
 ## 2022.02
 * Updated: Coding standards to v2.1.2, PHP8 sniffer fixes.

--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -185,7 +185,7 @@ class Force_Plugin_Activation {
 			return $plugins;
 		}
 
-		// Plugins like Jetpack sync may run
+		// Plugins like Jetpack sync may run this outside of the current screen scope.
 		if ( ! function_exists( 'get_current_screen' ) ) {
 			return $plugins;
 		}

--- a/wp-content/mu-plugins/force-plugin-activation.php
+++ b/wp-content/mu-plugins/force-plugin-activation.php
@@ -185,12 +185,17 @@ class Force_Plugin_Activation {
 			return $plugins;
 		}
 
+		// Plugins like Jetpack sync may run
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return $plugins;
+		}
+
 		$screen = get_current_screen();
 		if ( $screen && $screen->in_admin( 'network' ) ) {
 			return $plugins;
 		}
 
-		foreach ( (array) $this->force_network_only as $slug ) {
+		foreach ( $this->force_network_only as $slug ) {
 			if ( ! isset( $plugins[ $slug ] ) ) {
 				continue;
 			}


### PR DESCRIPTION
## What does this do/fix?

Just ran into this on another project, the `get_current_screen()` function is not guaranteed to be available depending on what's calling the `all_plugins` filter, in this case Jetpack Sync, which collects plugin data outside of a screen scope.

Example error logs:

```
PHP Fatal error:  Uncaught Error: Call to undefined function Tribe\\Mu\\get_current_screen() in /nas/content/live/sitenamehere/wp-content/mu-plugins/force-plugin-activation.php:180\nStack trace:\n#0 /nas/content/live/sitenamehere/wp-includes/class-wp-hook.php(292): Tribe\\Mu\\Force_Plugin_Activation->hide_from_blog(Array)\n#1 /nas/content/live/sitenamehere/wp-includes/plugin.php(212): WP_Hook->apply_filters(Array, Array)\n#2 /nas/content/live/sitenamehere/wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/class-functions.php(523): apply_filters('all_plugins', Array)\n#3 [internal function]: Automattic\\Jetpack\\Sync\\Functions::get_plugins()\n#4 /nas/content/live/sitenamehere/wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/modules/class-callables.php(233): call_user_func(Array)\n#5 [internal function]: Automattic\\Jetpack\\Sync\\Modules\\Callables->get_callable(Array)\n#6 /nas/content/live/sitenamehere/wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/modules/class-callables.php(216): array_map(Array, Array)\n#7 /na in /nas/content/live/sitenamehere/wp-content/mu-plugins/force-plugin-activation.php on line 180
```

## QA

- If a site is using Jetpack, and has Sync enabled, no more errors should occur in the error log.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's an mu plugin update.
- [ ] No, I need help figuring out how to write the tests.

