### PR TITLE
[SQONE-567] Fixes nested bullets/numbers on lists

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Updated: Aligns accordion component with WAI-ARIA standard
 * Fixed: Jetpack sync calls the `all_plugins` filter outside of a screen context, causing fatal errors in our force plugin activation MU plugin when using multisite.
 * Added: Enable/disable scrolling behavior on accordion blocks
+* Fixed: Adds styling for nested lists in t-sink context
 
 ## 2022.02
 * Updated: Coding standards to v2.1.2, PHP8 sniffer fixes.

--- a/wp-content/themes/core/assets/css/src/theme/typography/lists.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/typography/lists.pcss
@@ -32,6 +32,11 @@ li {}
 .t-sink > ul {
 	list-style: disc outside;
 	padding-left: 1.5em;
+
+	ul {
+		list-style: disc outside;
+		padding-left: 1.5em;
+	}
 }
 
 /* -------------------------------------------------------------------------
@@ -65,8 +70,13 @@ li {}
 
 .t-list--numbered,
 .t-sink > ol {
-	list-style: decimal outside;
 	padding-left: 1.5em;
+	list-style: decimal outside;
+
+	ol {
+		padding-left: 1.5em;
+		list-style: decimal outside;
+	}
 }
 
 /* -------------------------------------------------------------------------

--- a/wp-content/themes/core/assets/css/src/theme/typography/lists.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/typography/lists.pcss
@@ -48,6 +48,11 @@ li {}
 	list-style: none;
 	padding-left: 0;
 
+	ul {
+		list-style: none;
+		padding-left: 0;
+	}
+
 	li {
 		position: relative;
 		padding-left: var(--spacer-40);
@@ -88,6 +93,12 @@ li {}
 	list-style: none;
 	padding-left: 0;
 	counter-reset: list-number;
+
+	ol {
+		list-style: none;
+		padding-left: 0;
+		counter-reset: list-number;
+	}
 
 	li {
 		position: relative;


### PR DESCRIPTION
## What does this do/fix?

- Ensures list bullets and numbers are reflected in nested lists for regular and stylized lists under `t-sink`


## QA

Links to relevant issues
- [SQONE-567](https://moderntribe.atlassian.net/browse/SQONE-567)

Screenshots/video:
![lists](https://user-images.githubusercontent.com/14989492/159073461-6c8b0bdf-6305-448d-956d-98cad1258c87.png)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

