### PR TITLE
[BUGFIX]: Content loop pagination and Index controller refactor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,7 @@ tab_width = 4
 
 [wp-content/{plugins,themes}/core/**.php]
 indent_style = tab
+indent_size = 4
 ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
 ij_formatter_tags_enabled = false

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ local-config.php
 cache-config.php
 tests-config.php
 build-process.php
+wp-content/db.php
 wp-content/uploads/
 wp-content/blogs.dir/
 wp-content/upgrade/
@@ -142,5 +143,5 @@ phpcs.xml
 
 
 
-# Added by so cli 
+# Added by so cli
 *.local.php

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.03
+* Fixed: Refactor index controller to use proper meta fetching objects and general code clean up.
+* Fixed: Show same header logic on the Post Tag archive as the Category Archive.
+* Added: Ignore the Query Monitor plugin's automatically created db.php file.
+* Added: Pagination Helper Trait.
+* Fixed: .editorconfig incorrect tabbing for PHP files (thanks Caleb).
+* Fixed: Missing pagination on the content loop block component.
+* Fixed: Visibility of public $sidebar_id's in all controllers.
 * Fixed: Gravity Forms filter parameter types changed for v2.5 and above.
 * Updated WordPress: 5.9.2 / new tests dump.sql
 * Updated plugins: ACF, TEC, Gravity Forms, Yoast

--- a/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
+++ b/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php
@@ -15,7 +15,7 @@ abstract class Abstract_Controller {
 	 * @throws \DI\DependencyException
 	 * @throws \DI\NotFoundException
 	 *
-	 * @return \Tribe\Project\Templates\Components\Abstract_Controller
+	 * @return static
 	 */
 	public static function factory( array $args = [] ): Abstract_Controller {
 		return tribe_project()->container()->make( static::class, [ 'args' => $args ] );

--- a/wp-content/plugins/core/src/Templates/Components/Traits/With_Pagination_Helper.php
+++ b/wp-content/plugins/core/src/Templates/Components/Traits/With_Pagination_Helper.php
@@ -9,7 +9,7 @@ trait With_Pagination_Helper {
 	}
 
 	public function is_page_one(): bool {
-		return 1 === $this->get_current_page();
+		return $this->get_current_page() <= 1;
 	}
 
 }

--- a/wp-content/plugins/core/src/Templates/Components/Traits/With_Pagination_Helper.php
+++ b/wp-content/plugins/core/src/Templates/Components/Traits/With_Pagination_Helper.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Templates\Components\Traits;
+
+trait With_Pagination_Helper {
+
+	public function get_current_page(): int {
+		return (int) get_query_var( 'paged', 1 );
+	}
+
+	public function is_page_one(): bool {
+		return 1 === $this->get_current_page();
+	}
+
+}

--- a/wp-content/themes/core/components/blocks/content_loop/Content_Loop_Controller.php
+++ b/wp-content/themes/core/components/blocks/content_loop/Content_Loop_Controller.php
@@ -26,6 +26,7 @@ class Content_Loop_Controller extends Abstract_Controller {
 	public const LEADIN            = 'leadin';
 	public const POSTS             = 'posts';
 	public const TITLE             = 'title';
+	public const ENABLE_PAGINATION = 'enable_pagination';
 
 	/**
 	 * @var string[]
@@ -62,6 +63,7 @@ class Content_Loop_Controller extends Abstract_Controller {
 	private string $layout;
 	private string $leadin;
 	private string $title;
+	private bool $enable_pagination;
 
 	public function __construct( array $args = [] ) {
 		$args = $this->parse_args( $args );
@@ -72,6 +74,7 @@ class Content_Loop_Controller extends Abstract_Controller {
 		$this->content_classes   = (array) $args[ self::CONTENT_CLASSES ];
 		$this->cta               = (array) $args[ self::CTA ];
 		$this->description       = (string) $args[ self::DESCRIPTION ];
+		$this->enable_pagination = (bool) $args[ self::ENABLE_PAGINATION ];
 		$this->layout            = (string) $args[ self::LAYOUT ];
 		$this->leadin            = (string) $args[ self::LEADIN ];
 		$this->posts             = (array) $args[ self::POSTS ];
@@ -94,6 +97,10 @@ class Content_Loop_Controller extends Abstract_Controller {
 
 	public function get_layout(): string {
 		return $this->layout;
+	}
+
+	public function is_pagination_enabled(): bool {
+		return $this->enable_pagination;
 	}
 
 	public function get_posts_card_args( string $layout = Card_Controller::STYLE_PLAIN ): array {
@@ -274,6 +281,7 @@ class Content_Loop_Controller extends Abstract_Controller {
 			self::CONTENT_CLASSES   => [],
 			self::CTA               => [],
 			self::DESCRIPTION       => '',
+			self::ENABLE_PAGINATION => true,
 			self::LAYOUT            => Content_Loop_Block::LAYOUT_ROW,
 			self::LEADIN            => '',
 			self::POSTS             => [],

--- a/wp-content/themes/core/components/blocks/content_loop/content_loop.php
+++ b/wp-content/themes/core/components/blocks/content_loop/content_loop.php
@@ -45,7 +45,7 @@ $c = Content_Loop_Controller::factory( $args );
 
 			<?php elseif ( $c->get_layout() === Content_Loop::LAYOUT_COLUMNS ) : ?>
 				<!-- Columns Layout -->
-				<?php foreach ( $c->get_posts_card_args( Card_Controller::STYLE_PLAIN ) as $card_args ) { ?>
+				<?php foreach ( $c->get_posts_card_args() as $card_args ) { ?>
 					<?php get_template_part( 'components/card/card', '', $card_args ); ?>
 				<?php } ?>
 
@@ -58,7 +58,9 @@ $c = Content_Loop_Controller::factory( $args );
 			<?php endif; ?>
 		</div>
 
-		<?php get_template_part( 'components/pagination/loop/loop' ); ?>
+		<?php if ( $c->is_pagination_enabled() ) {
+			get_template_part( 'components/pagination/loop/loop', 'index' );
+		} ?>
 
 	</div>
 </section>

--- a/wp-content/themes/core/components/blocks/content_loop/content_loop.php
+++ b/wp-content/themes/core/components/blocks/content_loop/content_loop.php
@@ -1,12 +1,13 @@
 <?php declare(strict_types=1);
 
 use Tribe\Project\Blocks\Types\Content_Loop\Content_Loop;
+use Tribe\Project\Templates\Components\blocks\content_loop\Content_Loop_Controller;
 use Tribe\Project\Templates\Components\card\Card_Controller;
 
 /**
  * @var array $args Arguments passed to the template
  */
-$c = \Tribe\Project\Templates\Components\blocks\content_loop\Content_Loop_Controller::factory( $args );
+$c = Content_Loop_Controller::factory( $args );
 ?>
 
 <section <?php echo $c->get_classes(); ?> <?php echo $c->get_attrs(); ?>>
@@ -25,7 +26,7 @@ $c = \Tribe\Project\Templates\Components\blocks\content_loop\Content_Loop_Contro
 				<div class="b-content-loop__featured">
 					<?php foreach ( $c->get_posts_card_args() as $index => $card_args ) { ?>
 						<?php if ( $index === 0 ) : ?>
-							<?php get_template_part( 'components/card/card', null, $card_args ); ?>
+							<?php get_template_part( 'components/card/card', '', $card_args ); ?>
 						<?php endif; ?>
 					<?php } ?>
 				</div>
@@ -33,7 +34,7 @@ $c = \Tribe\Project\Templates\Components\blocks\content_loop\Content_Loop_Contro
 				<div class="b-content-loop__secondary">
 					<?php foreach ( $c->get_posts_card_args( Card_Controller::STYLE_INLINE ) as $index => $card_args ) { ?>
 						<?php if ( $index !== 0 ) : ?>
-							<?php get_template_part( 'components/card/card', null, $card_args ); ?>
+							<?php get_template_part( 'components/card/card', '', $card_args ); ?>
 						<?php endif; ?>
 					<?php } ?>
 
@@ -44,18 +45,20 @@ $c = \Tribe\Project\Templates\Components\blocks\content_loop\Content_Loop_Contro
 
 			<?php elseif ( $c->get_layout() === Content_Loop::LAYOUT_COLUMNS ) : ?>
 				<!-- Columns Layout -->
-				<?php foreach ( $c->get_posts_card_args( Card_Controller::STYLE_PLAIN ) as $index => $card_args ) { ?>
-					<?php get_template_part( 'components/card/card', null, $card_args ); ?>
+				<?php foreach ( $c->get_posts_card_args( Card_Controller::STYLE_PLAIN ) as $card_args ) { ?>
+					<?php get_template_part( 'components/card/card', '', $card_args ); ?>
 				<?php } ?>
 
 			<?php else : ?>
 				<!-- Row Layout -->
-				<?php foreach ( $c->get_posts_card_args( Card_Controller::STYLE_INLINE ) as $index => $card_args ) { ?>
-					<?php get_template_part( 'components/card/card', null, $card_args ); ?>
+				<?php foreach ( $c->get_posts_card_args( Card_Controller::STYLE_INLINE ) as $card_args ) { ?>
+					<?php get_template_part( 'components/card/card', '', $card_args ); ?>
 				<?php } ?>
 
 			<?php endif; ?>
 		</div>
+
+		<?php get_template_part( 'components/pagination/loop/loop' ); ?>
 
 	</div>
 </section>

--- a/wp-content/themes/core/routes/archive/archive.php
+++ b/wp-content/themes/core/routes/archive/archive.php
@@ -24,7 +24,7 @@ do_action( 'get_sidebar', null );
 get_template_part(
 	'components/sidebar/sidebar',
 	'index',
-	[ Sidebar_Controller::SIDEBAR_ID => $c->sidebar_id ]
+	[ Sidebar_Controller::SIDEBAR_ID => $c->get_sidebar_id() ]
 );
 
 get_footer();

--- a/wp-content/themes/core/routes/index/Index_Controller.php
+++ b/wp-content/themes/core/routes/index/Index_Controller.php
@@ -2,24 +2,45 @@
 
 namespace Tribe\Project\Templates\Routes\index;
 
+use Tribe\Libs\Taxonomy\Term_Object;
 use Tribe\Project\Blocks\Types\Content_Loop\Content_Loop;
 use Tribe\Project\Object_Meta\Post_Archive_Featured_Settings;
 use Tribe\Project\Object_Meta\Post_Archive_Settings;
+use Tribe\Project\Object_Meta\Taxonomy_Archive_Settings;
+use Tribe\Project\Settings\Post_Settings;
 use Tribe\Project\Templates\Components\Abstract_Controller;
 use Tribe\Project\Templates\Components\blocks\content_loop\Content_Loop_Controller;
 use Tribe\Project\Templates\Components\header\subheader\Subheader_Controller;
 use Tribe\Project\Templates\Components\Traits\Page_Title;
 use Tribe\Project\Templates\Components\Traits\Post_List_Field_Formatter;
+use Tribe\Project\Templates\Components\Traits\With_Pagination_Helper;
+use WP_Term;
 
 class Index_Controller extends Abstract_Controller {
 
 	use Post_List_Field_Formatter;
 	use Page_Title;
+	use With_Pagination_Helper;
 
-	public string $sidebar_id = '';
+	public const SIDEBAR_ID = 'sidebar_id';
+
+	protected string $sidebar_id = '';
+	protected Post_Settings $post_settings;
+
+	public function __construct( Post_Settings $post_settings, array $args = [] ) {
+		$args = $this->parse_args( $args );
+
+		$this->sidebar_id    = (string) $args[ self::SIDEBAR_ID ];
+		$this->post_settings = $post_settings;
+	}
+
+	public function get_sidebar_id(): string {
+		return $this->sidebar_id;
+	}
 
 	public function get_content_loop_args(): array {
 		global $wp_query;
+
 		$posts = [];
 
 		if ( ! empty( $wp_query->posts ) ) {
@@ -37,11 +58,15 @@ class Index_Controller extends Abstract_Controller {
 	}
 
 	/**
-	 * Get posts in the featured posts from the Post Archive Settings page
+	 * Get posts in the featured posts from the Post Archive Settings page.
+	 *
+	 * @param int $max_posts The maximum number of featured posts to display.
+	 *
+	 * @return array
 	 */
-	public function get_content_loop_featured_args(): array {
+	public function get_content_loop_featured_args( int $max_posts = 6 ): array {
 
-		$featured_post_query = get_field( Post_Archive_Featured_Settings::FEATURED_POSTS, 'option' );
+		$featured_post_query = $this->post_settings->get_setting( Post_Archive_Featured_Settings::FEATURED_POSTS, [] );
 		$featured_post_array = [];
 
 		if ( empty( $featured_post_query ) ) {
@@ -54,17 +79,12 @@ class Index_Controller extends Abstract_Controller {
 
 		return [
 			Content_Loop_Controller::LAYOUT => Content_Loop::LAYOUT_FEATURE,
-			Content_Loop_Controller::POSTS  => array_slice( $featured_post_array, 0, 6 ),
+			Content_Loop_Controller::POSTS  => array_slice( $featured_post_array, 0, $max_posts ),
 		];
 	}
 
-	// TODO: This should be a utility method somewhere
-	public function get_current_page(): int {
-		return (int) get_query_var( 'paged' ) ?: 1;
-	}
-
 	/**
-	 * Prepare data for the Subheader Component
+	 * Prepare data for the Subheader Component.
 	 *
 	 * @see \Tribe\Project\Templates\Components\header\subheader\Subheader_Controller
 	 *
@@ -73,45 +93,49 @@ class Index_Controller extends Abstract_Controller {
 	public function get_subheader_args(): array {
 		$args = [];
 
-		if ( is_category() ) {
-			$term = get_queried_object();
-
-			if ( ! empty( $term ) ) {
-				$args[ Subheader_Controller::TITLE ]       = $term->name;
-				$args[ Subheader_Controller::DESCRIPTION ] = $term->category_description;
-
-				$hero_image = get_field( Post_Archive_Settings::HERO_IMAGE, $term->taxonomy.'_'.$term->term_id );
-				if ( ! empty( $hero_image ) ) {
-					$args[ Subheader_Controller::HERO_IMAGE_ID ] = $hero_image['ID'];
-				}
-			}
-
-			return $args;
+		if ( is_category() || is_tag() ) {
+			return $this->get_subheader_core_taxonomy_args();
 		}
 
-		// Manually Set via Post Archive Settings
+		// Manually Set via Posts > Settings.
 		if ( is_front_page() ) {
-			$title = get_field( 'title', 'option' );
-			if ( ! empty( $title ) ) {
-				$args[ Subheader_Controller::TITLE ] = $title;
-			}
-			$description = get_field( 'description', 'option' );
-			if ( ! empty( $description ) ) {
-				$args[ Subheader_Controller::DESCRIPTION ] = $description;
-			}
-
-			$hero_image = get_field( 'hero_image', 'option' );
-			if ( ! empty( $hero_image ) ) {
-				$args[ Subheader_Controller::HERO_IMAGE_ID ] = $hero_image['ID'];
-			}
-
-			return $args;
+			return $this->get_subheader_front_page_args();
 		}
 
 		// Default
 		$args[ Subheader_Controller::TITLE ] = $this->get_page_title();
 
 		return $args;
+	}
+
+	protected function get_subheader_core_taxonomy_args(): array {
+		$term = get_queried_object();
+
+		if ( ! $term instanceof WP_Term ) {
+			return [];
+		}
+
+		$category = Term_Object::factory( $term->term_id );
+
+		return array_filter( [
+			Subheader_Controller::TITLE         => $term->name,
+			Subheader_Controller::DESCRIPTION   => $term->description,
+			Subheader_Controller::HERO_IMAGE_ID => $category->get_meta( Taxonomy_Archive_Settings::HERO_IMAGE )['ID'] ?? [],
+		] );
+	}
+
+	protected function get_subheader_front_page_args(): array {
+		return array_filter( [
+			Subheader_Controller::TITLE         => $this->post_settings->get_setting( Post_Archive_Settings::TITLE, '' ),
+			Subheader_Controller::DESCRIPTION   => $this->post_settings->get_setting( Post_Archive_Settings::DESCRIPTION, '' ),
+			Subheader_Controller::HERO_IMAGE_ID => $this->post_settings->get_setting( Post_Archive_Settings::HERO_IMAGE, [] )['ID'] ?? [],
+		] );
+	}
+
+	protected function defaults(): array {
+		return [
+			self::SIDEBAR_ID => '',
+		];
 	}
 
 }

--- a/wp-content/themes/core/routes/index/Index_Controller.php
+++ b/wp-content/themes/core/routes/index/Index_Controller.php
@@ -78,8 +78,9 @@ class Index_Controller extends Abstract_Controller {
 		}
 
 		return [
-			Content_Loop_Controller::LAYOUT => Content_Loop::LAYOUT_FEATURE,
-			Content_Loop_Controller::POSTS  => array_slice( $featured_post_array, 0, $max_posts ),
+			Content_Loop_Controller::LAYOUT            => Content_Loop::LAYOUT_FEATURE,
+			Content_Loop_Controller::POSTS             => array_slice( $featured_post_array, 0, $max_posts ),
+			Content_Loop_Controller::ENABLE_PAGINATION => false,
 		];
 	}
 

--- a/wp-content/themes/core/routes/index/index.php
+++ b/wp-content/themes/core/routes/index/index.php
@@ -10,14 +10,16 @@ get_header();
 	<main id="main-content">
 		<?php get_template_part( 'components/header/subheader/subheader', 'index', $c->get_subheader_args() ); ?>
 
-		<?php if ( have_posts() ) :
-			if ( $c->is_page_one() && ! empty( $c->get_content_loop_featured_args() ) ) :
+		<?php if ( have_posts() ) {
+			// Featured posts
+			if ( $c->is_page_one() && ! empty( $c->get_content_loop_featured_args() ) ) {
 				get_template_part( 'components/blocks/content_loop/content_loop', null, $c->get_content_loop_featured_args() );
-			endif;
-			get_template_part( 'components/blocks/content_loop/content_loop', null, $c->get_content_loop_args() ); ?>
-		<?php else :
+			}
+
+			get_template_part( 'components/blocks/content_loop/content_loop', null, $c->get_content_loop_args() );
+		} else {
 			get_template_part( 'components/no_results/no_results', 'index' );
-		endif; ?>
+		} ?>
 	</main>
 <?php
 do_action( 'get_sidebar', null );

--- a/wp-content/themes/core/routes/index/index.php
+++ b/wp-content/themes/core/routes/index/index.php
@@ -11,7 +11,7 @@ get_header();
 		<?php get_template_part( 'components/header/subheader/subheader', 'index', $c->get_subheader_args() ); ?>
 
 		<?php if ( have_posts() ) :
-			if ( $c->get_current_page() === 1 && ! empty( $c->get_content_loop_featured_args() ) ) :
+			if ( $c->is_page_one() && ! empty( $c->get_content_loop_featured_args() ) ) :
 				get_template_part( 'components/blocks/content_loop/content_loop', null, $c->get_content_loop_featured_args() );
 			endif;
 			get_template_part( 'components/blocks/content_loop/content_loop', null, $c->get_content_loop_args() ); ?>
@@ -24,7 +24,7 @@ do_action( 'get_sidebar', null );
 get_template_part(
 	'components/sidebar/sidebar',
 	'index',
-	[ Sidebar_Controller::SIDEBAR_ID => $c->sidebar_id ]
+	[ Sidebar_Controller::SIDEBAR_ID => $c->get_sidebar_id() ]
 );
 
 get_footer();

--- a/wp-content/themes/core/routes/not_found/Not_Found_Controller.php
+++ b/wp-content/themes/core/routes/not_found/Not_Found_Controller.php
@@ -7,18 +7,30 @@ use Tribe\Project\Templates\Components\search_form\Search_Form_Controller;
 
 class Not_Found_Controller extends Abstract_Controller {
 
-	/**
-	 * @var int|string
-	 */
-	public $sidebar_id = '';
+	public const SIDEBAR_ID = 'sidebar_id';
 
-	/**
-	 * @return array
-	 */
+	protected string $sidebar_id;
+
+	public function __construct( array $args = [] ) {
+		$args = $this->parse_args( $args );
+
+		$this->sidebar_id = (string) $args[ self::SIDEBAR_ID ];
+	}
+
 	public function get_search_form_args(): array {
 		return [
 			Search_Form_Controller::FORM_ID     => uniqid( 's-' ),
 			Search_Form_Controller::PLACEHOLDER => __( 'Search', 'tribe' ),
+		];
+	}
+
+	public function get_sidebar_id(): string {
+		return $this->sidebar_id;
+	}
+
+	protected function defaults(): array {
+		return [
+			self::SIDEBAR_ID => '',
 		];
 	}
 

--- a/wp-content/themes/core/routes/not_found/not_found.php
+++ b/wp-content/themes/core/routes/not_found/not_found.php
@@ -38,7 +38,7 @@ do_action( 'get_sidebar', null );
 get_template_part(
 	'components/sidebar/sidebar',
 	'index',
-	[ Sidebar_Controller::SIDEBAR_ID => $c->sidebar_id ]
+	[ Sidebar_Controller::SIDEBAR_ID => $c->get_sidebar_id() ]
 );
 get_footer();
 

--- a/wp-content/themes/core/routes/page/page.php
+++ b/wp-content/themes/core/routes/page/page.php
@@ -23,6 +23,6 @@ do_action( 'get_sidebar', null );
 get_template_part(
 	'components/sidebar/sidebar',
 	'page',
-	[ Sidebar_Controller::SIDEBAR_ID => $c->sidebar_id ]
+	[ Sidebar_Controller::SIDEBAR_ID => $c->get_sidebar_id() ]
 );
 get_footer();

--- a/wp-content/themes/core/routes/search/search.php
+++ b/wp-content/themes/core/routes/search/search.php
@@ -13,9 +13,9 @@ get_header();
 			<div class="search-results__container">
 				<h1 class="h2 search-results__title"><?php _e( 'Search', 'tribe' ); ?></h1>
 
-				<?php get_template_part( 'components/search_form/search_form', null, $c->get_search_form_args() ); ?>
+				<?php get_template_part( 'components/search_form/search_form', '', $c->get_search_form_args() ); ?>
 
-				<?php get_template_part( 'components/text/text', null, $c->get_results_text_args() ); ?>
+				<?php get_template_part( 'components/text/text', '', $c->get_results_text_args() ); ?>
 
 				<?php
 				if ( have_posts() ) :
@@ -35,6 +35,6 @@ do_action( 'get_sidebar', null );
 get_template_part(
 	'components/sidebar/sidebar',
 	'index',
-	[ Sidebar_Controller::SIDEBAR_ID => $c->sidebar_id ]
+	[ Sidebar_Controller::SIDEBAR_ID => $c->get_sidebar_id() ]
 );
 get_footer();

--- a/wp-content/themes/core/routes/single/Single_Controller.php
+++ b/wp-content/themes/core/routes/single/Single_Controller.php
@@ -18,10 +18,15 @@ class Single_Controller extends Abstract_Controller {
 	use Page_Title;
 	use Primary_Term;
 
-	/**
-	 * @var int|string
-	 */
-	public $sidebar_id = '';
+	public const SIDEBAR_ID = 'sidebar_id';
+
+	protected string $sidebar_id;
+
+	public function __construct( array $args = [] ) {
+		$args = $this->parse_args( $args );
+
+		$this->sidebar_id = (string) $args[ self::SIDEBAR_ID ];
+	}
 
 	public function get_subheader_args(): array {
 		global $post;
@@ -83,6 +88,16 @@ class Single_Controller extends Abstract_Controller {
 				Image_Controller::IMG_ALT_TEXT => ! empty( $alt_text ) ? $alt_text : '',
 				Image_Controller::HTML         => ! empty( $caption ) ? '<figcaption class="item-single__featured-image-caption t-caption">' . wp_get_attachment_caption( $image_id ) . '</figcaption>' : '',
 			];
+	}
+
+	public function get_sidebar_id(): string {
+		return $this->sidebar_id;
+	}
+
+	protected function defaults(): array {
+		return [
+			self::SIDEBAR_ID => '',
+		];
 	}
 
 }

--- a/wp-content/themes/core/routes/single/single.php
+++ b/wp-content/themes/core/routes/single/single.php
@@ -69,6 +69,6 @@ do_action( 'get_sidebar', null );
 get_template_part(
 	'components/sidebar/sidebar',
 	'single',
-	[ Sidebar_Controller::SIDEBAR_ID => $c->sidebar_id ]
+	[ Sidebar_Controller::SIDEBAR_ID => $c->get_sidebar_id() ]
 );
 get_footer();


### PR DESCRIPTION
## What does this do/fix?

- The archive/post index loops currently have no pagination and no way to view more posts. This adds pagination to the content loop block component (with an option to disable it, like for featured posts).
- Lots of other bug fixes / code clean up. See the changelog updates.

## QA

Homepage with featured posts, 5 posts per page and pagination:
![image](https://user-images.githubusercontent.com/1066195/160713668-7b068f4c-f671-4524-876c-a293eb5e4a95.png)

Tag Archive with custom image:
![image](https://user-images.githubusercontent.com/1066195/160713732-5f952041-6175-4f3e-9d7c-9043acbd5ad9.png)

Category archive with custom image:
![image](https://user-images.githubusercontent.com/1066195/160713794-16d583eb-31a5-4352-8882-d8b304651ddf.png)

Page two of category archive:
![image](https://user-images.githubusercontent.com/1066195/160713846-20596660-747b-4fc4-8b94-166410996be7.png)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's controller/component updates.
- [ ] No, I need help figuring out how to write the tests.

