### PR TITLE
Feature: instantiate block models with the container instead of statically

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2022.04
+* Changed: all block models are now instantiated with the container to support auto wiring.
+
 ## 2022.03
 * Updated: Misc config updates for Dokku and Docker nginx & PHP.
 * Fixed: Gravity Forms filter parameter types changed for v2.5 and above.

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.04
-* Changed: all block models are now instantiated with the container to support auto wiring.
+* Changed: all block models are now instantiated with the container to support dependency injection.
 
 ## 2022.03
 * Updated: Misc config updates for Dokku and Docker nginx & PHP.

--- a/composer.lock
+++ b/composer.lock
@@ -1362,16 +1362,16 @@
         },
         {
             "name": "moderntribe/tribe-libs",
-            "version": "3.4.12",
+            "version": "3.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moderntribe/tribe-libs.git",
-                "reference": "cc807620b2f48795a622ce79c6cac692523b01f0"
+                "reference": "1d63f2e172d44a3e9df456e2b0ac3513dbf80fa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moderntribe/tribe-libs/zipball/cc807620b2f48795a622ce79c6cac692523b01f0",
-                "reference": "cc807620b2f48795a622ce79c6cac692523b01f0",
+                "url": "https://api.github.com/repos/moderntribe/tribe-libs/zipball/1d63f2e172d44a3e9df456e2b0ac3513dbf80fa2",
+                "reference": "1d63f2e172d44a3e9df456e2b0ac3513dbf80fa2",
                 "shasum": ""
             },
             "require": {
@@ -1480,9 +1480,9 @@
             "description": "A library for use on Modern Tribe service projects.",
             "support": {
                 "issues": "https://github.com/moderntribe/tribe-libs/issues",
-                "source": "https://github.com/moderntribe/tribe-libs/tree/3.4.12"
+                "source": "https://github.com/moderntribe/tribe-libs/tree/3.4.13"
             },
-            "time": "2022-03-24T20:03:05+00:00"
+            "time": "2022-04-05T14:10:27+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5691,16 +5691,16 @@
         },
         {
             "name": "moderntribe/coding-standards",
-            "version": "v2.1.3",
+            "version": "v2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moderntribe/coding-standards.git",
-                "reference": "5a0a7c7bf274d95d32f022d1bd05e16db5d96818"
+                "reference": "ac1aadcabeabfd33b6e5d2d9ed43c009c7a2485f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moderntribe/coding-standards/zipball/5a0a7c7bf274d95d32f022d1bd05e16db5d96818",
-                "reference": "5a0a7c7bf274d95d32f022d1bd05e16db5d96818",
+                "url": "https://api.github.com/repos/moderntribe/coding-standards/zipball/ac1aadcabeabfd33b6e5d2d9ed43c009c7a2485f",
+                "reference": "ac1aadcabeabfd33b6e5d2d9ed43c009c7a2485f",
                 "shasum": ""
             },
             "require": {
@@ -5740,9 +5740,9 @@
             ],
             "support": {
                 "issues": "https://github.com/moderntribe/coding-standards/issues",
-                "source": "https://github.com/moderntribe/coding-standards/tree/v2.1.3"
+                "source": "https://github.com/moderntribe/coding-standards/tree/v2.1.4"
             },
-            "time": "2022-03-14T16:48:45+00:00"
+            "time": "2022-04-04T22:46:50+00:00"
         },
         {
             "name": "mustache/mustache",

--- a/wp-content/themes/core/blocks/accordion/accordion.php
+++ b/wp-content/themes/core/blocks/accordion/accordion.php
@@ -5,10 +5,10 @@ use Tribe\Project\Blocks\Types\Accordion\Accordion_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Accordion_Model( $args['block'] );
+$model = tribe_project()->container()->make( Accordion_Model::class, $args );
 
 get_template_part(
 	'components/blocks/accordion/accordion',
-	null,
+	'',
 	$model->get_data()
 );

--- a/wp-content/themes/core/blocks/buttons/buttons.php
+++ b/wp-content/themes/core/blocks/buttons/buttons.php
@@ -5,5 +5,5 @@ use Tribe\Project\Blocks\Types\Buttons\Buttons_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Buttons_Model( $args['block'] );
-get_template_part( 'components/blocks/buttons/buttons', null, $model->get_data() );
+$model = tribe_project()->container()->make( Buttons_Model::class, $args );
+get_template_part( 'components/blocks/buttons/buttons', '', $model->get_data() );

--- a/wp-content/themes/core/blocks/buttons/buttons.php
+++ b/wp-content/themes/core/blocks/buttons/buttons.php
@@ -6,4 +6,9 @@ use Tribe\Project\Blocks\Types\Buttons\Buttons_Model;
  * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Buttons_Model::class, $args );
-get_template_part( 'components/blocks/buttons/buttons', '', $model->get_data() );
+
+get_template_part(
+	'components/blocks/buttons/buttons',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/cardgrid/cardgrid.php
+++ b/wp-content/themes/core/blocks/cardgrid/cardgrid.php
@@ -5,10 +5,10 @@ use Tribe\Project\Blocks\Types\Card_Grid\Card_Grid_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Card_Grid_Model( $args['block'] );
+$model = tribe_project()->container()->make( Card_Grid_Model::class, $args );
 
 get_template_part(
 	'components/blocks/card_grid/card_grid',
-	null,
+	'',
 	$model->get_data()
 );

--- a/wp-content/themes/core/blocks/contentcolumns/contentcolumns.php
+++ b/wp-content/themes/core/blocks/contentcolumns/contentcolumns.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Content_Columns\Content_Columns_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Content_Columns_Model( $args['block'] );
-get_template_part( 'components/blocks/content_columns/content_columns', null, $model->get_data() );
+$model = tribe_project()->container()->make( Content_Columns_Model::class, $args );
+
+get_template_part(
+	'components/blocks/content_columns/content_columns',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/contentcolumns/contentcolumns.php
+++ b/wp-content/themes/core/blocks/contentcolumns/contentcolumns.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Content_Columns\Content_Columns_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Content_Columns_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/contentloop/contentloop.php
+++ b/wp-content/themes/core/blocks/contentloop/contentloop.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Content_Loop\Content_Loop_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Content_Loop_Model( $args['block'] );
-get_template_part( 'components/blocks/content_loop/content_loop', null, $model->get_data() );
+$model = tribe_project()->container()->make( Content_Loop_Model::class, $args );
+
+get_template_part(
+	'components/blocks/content_loop/content_loop',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/gallerygrid/gallerygrid.php
+++ b/wp-content/themes/core/blocks/gallerygrid/gallerygrid.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Gallery_Grid\Gallery_Grid_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Gallery_Grid_Model( $args['block'] );
-get_template_part( 'components/blocks/gallery_grid/gallery_grid', null, $model->get_data() );
+$model = tribe_project()->container()->make( Gallery_Grid_Model::class, $args );
+
+get_template_part(
+	'components/blocks/gallery_grid/gallery_grid',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/galleryslider/galleryslider.php
+++ b/wp-content/themes/core/blocks/galleryslider/galleryslider.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Gallery_Slider\Gallery_Slider_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Gallery_Slider_Model( $args['block'] );
-get_template_part( 'components/blocks/gallery_slider/gallery_slider', null, $model->get_data() );
+$model = tribe_project()->container()->make( Gallery_Slider_Model::class, $args );
+
+get_template_part(
+	'components/blocks/gallery_slider/gallery_slider',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/galleryslider/galleryslider.php
+++ b/wp-content/themes/core/blocks/galleryslider/galleryslider.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Gallery_Slider\Gallery_Slider_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Gallery_Slider_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/hero/hero.php
+++ b/wp-content/themes/core/blocks/hero/hero.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Hero\Hero_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Hero_Model( $args['block'] );
-get_template_part( 'components/blocks/hero/hero', null, $model->get_data() );
+$model = tribe_project()->container()->make( Hero_Model::class, $args );
+
+get_template_part(
+	'components/blocks/hero/hero',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/hero/hero.php
+++ b/wp-content/themes/core/blocks/hero/hero.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Hero\Hero_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Hero_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/icongrid/icongrid.php
+++ b/wp-content/themes/core/blocks/icongrid/icongrid.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Icon_Grid\Icon_Grid_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Icon_Grid_Model( $args['block'] );
-get_template_part( 'components/blocks/icon_grid/icon_grid', null, $model->get_data() );
+$model = tribe_project()->container()->make( Icon_Grid_Model::class, $args );
+
+get_template_part(
+	'components/blocks/icon_grid/icon_grid',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/icongrid/icongrid.php
+++ b/wp-content/themes/core/blocks/icongrid/icongrid.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Icon_Grid\Icon_Grid_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Icon_Grid_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/interstitial/interstitial.php
+++ b/wp-content/themes/core/blocks/interstitial/interstitial.php
@@ -5,10 +5,10 @@ use Tribe\Project\Blocks\Types\Interstitial\Interstitial_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Interstitial_Model( $args['block'] );
+$model = tribe_project()->container()->make( Interstitial_Model::class, $args );
 
 get_template_part(
 	'components/blocks/interstitial/interstitial',
-	null,
+	'',
 	$model->get_data()
 );

--- a/wp-content/themes/core/blocks/interstitial/interstitial.php
+++ b/wp-content/themes/core/blocks/interstitial/interstitial.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Interstitial\Interstitial_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Interstitial_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/leadform/leadform.php
+++ b/wp-content/themes/core/blocks/leadform/leadform.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Lead_Form\Lead_Form_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Lead_Form_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/leadform/leadform.php
+++ b/wp-content/themes/core/blocks/leadform/leadform.php
@@ -5,10 +5,10 @@ use Tribe\Project\Blocks\Types\Lead_Form\Lead_Form_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Lead_Form_Model( $args['block'] );
+$model = tribe_project()->container()->make( Lead_Form_Model::class, $args );
 
 get_template_part(
 	'components/blocks/lead_form/lead_form',
-	null,
+	'',
 	$model->get_data()
 );

--- a/wp-content/themes/core/blocks/links/links.php
+++ b/wp-content/themes/core/blocks/links/links.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Links\Links_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Links_Model( $args['block'] );
-get_template_part( 'components/blocks/links/links', null, $model->get_data() );
+$model = tribe_project()->container()->make( Links_Model::class, $args );
+
+get_template_part(
+	'components/blocks/links/links',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/logos/logos.php
+++ b/wp-content/themes/core/blocks/logos/logos.php
@@ -5,6 +5,10 @@ use \Tribe\Project\Blocks\Types\Logos\Logos_Model;
 /**
  * @var array $args Arguments passed to the module
  */
-$model = new Logos_Model( $args['block'] );
+$model = tribe_project()->container()->make( Logos_Model::class, $args );
 
-get_template_part( 'components/blocks/logos/logos', null, $model->get_data() );
+get_template_part(
+	'components/blocks/logos/logos',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/mediatext/mediatext.php
+++ b/wp-content/themes/core/blocks/mediatext/mediatext.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Media_Text\Media_Text_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Media_Text_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/mediatext/mediatext.php
+++ b/wp-content/themes/core/blocks/mediatext/mediatext.php
@@ -5,7 +5,7 @@ use Tribe\Project\Blocks\Types\Media_Text\Media_Text_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Media_Text_Model( $args['block'] );
+$model = tribe_project()->container()->make( Media_Text_Model::class, $args );
 
 get_template_part(
 	'components/blocks/media_text/media_text',

--- a/wp-content/themes/core/blocks/quote/quote.php
+++ b/wp-content/themes/core/blocks/quote/quote.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Quote\Quote_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Quote_Model( $args['block'] );
-get_template_part( 'components/blocks/quote/quote', null, $model->get_data() );
+$model = tribe_project()->container()->make( Quote_Model::class, $args );
+
+get_template_part(
+	'components/blocks/quote/quote',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/sectionnav/sectionnav.php
+++ b/wp-content/themes/core/blocks/sectionnav/sectionnav.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Section_Nav\Section_Nav_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Section_Nav_Model( $args['block'] );
-get_template_part( 'components/blocks/section_nav/section_nav', null, $model->get_data() );
+$model = tribe_project()->container()->make( Section_Nav_Model::class, $args );
+
+get_template_part(
+	'components/blocks/section_nav/section_nav',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/spacer/spacer.php
+++ b/wp-content/themes/core/blocks/spacer/spacer.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Spacer\Spacer_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Spacer_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/spacer/spacer.php
+++ b/wp-content/themes/core/blocks/spacer/spacer.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Spacer\Spacer_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Spacer_Model( $args['block'] );
-get_template_part( 'components/blocks/spacer/spacer', null, $model->get_data() );
+$model = tribe_project()->container()->make( Spacer_Model::class, $args );
+
+get_template_part(
+	'components/blocks/spacer/spacer',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/stats/stats.php
+++ b/wp-content/themes/core/blocks/stats/stats.php
@@ -3,7 +3,7 @@
 use Tribe\Project\Blocks\Types\Stats\Stats_Model;
 
 /**
- * @var array $args ACF block data..
+ * @var array $args ACF block data.
  */
 $model = tribe_project()->container()->make( Stats_Model::class, $args );
 

--- a/wp-content/themes/core/blocks/stats/stats.php
+++ b/wp-content/themes/core/blocks/stats/stats.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Stats\Stats_Model;
 /**
  * @var array $args ACF block data..
  */
-$model = new Stats_Model( $args['block'] );
-get_template_part( 'components/blocks/stats/stats', null, $model->get_data() );
+$model = tribe_project()->container()->make( Stats_Model::class, $args );
+
+get_template_part(
+	'components/blocks/stats/stats',
+	'',
+	$model->get_data()
+);

--- a/wp-content/themes/core/blocks/tabs/tabs.php
+++ b/wp-content/themes/core/blocks/tabs/tabs.php
@@ -5,5 +5,10 @@ use Tribe\Project\Blocks\Types\Tabs\Tabs_Model;
 /**
  * @var array $args ACF block data.
  */
-$model = new Tabs_Model( $args['block'] );
-get_template_part( 'components/blocks/tabs/tabs', null, $model->get_data() );
+$model = tribe_project()->container()->make( Tabs_Model::class, $args );
+
+get_template_part(
+	'components/blocks/tabs/tabs',
+	'',
+	$model->get_data()
+);


### PR DESCRIPTION
## What does this do/fix?

- All block models were statically instantiated across many views using the `new Block_Model()` keyword. This prevents developers from taking advantage of PHP-DI's dependency injection/autowiring/decorating etc. With this change, we can freely inject dependencies into block models or modify the Base_Model based on project needs.

## QA

Nothing should appear different.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a view/block model change.
- [ ] No, I need help figuring out how to write the tests.

