### PR TITLE
Bugfix/fix deploy commit messages

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -128,5 +128,5 @@ jobs:
         run: |
           echo 'Deploying ${{env.GITHUB_REF}} to ${{env.ENVIRONMENT}}'
           git add -Av
-          git commit --allow-empty -m 'Deploying ${env.BRANCH_NAME} to ${env.ENVIRONMENT}'
+          git commit --allow-empty -m 'Deploying ${{env.BRANCH_NAME}} to ${{env.ENVIRONMENT}}'
           git push origin master

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
           php -r "file_exists( 'local-config.json' ) || copy( 'local-config-sample.json', 'local-config.json' );"
-          echo "define( 'WP_ENVIRONMENT_TYPE', ${{env.ENVIROMENT}} );" >> local-config.php
+          echo "define( 'WP_ENVIRONMENT_TYPE', ${{env.ENVIRONMENT}} );" >> local-config.php
 
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
           php -r "file_exists( 'local-config.json' ) || copy( 'local-config-sample.json', 'local-config.json' );"
-          echo "define( 'WP_ENVIRONMENT_TYPE', ${{env.ENVIROMENT}} );" >> local-config.php
+          echo "define( 'WP_ENVIRONMENT_TYPE', ${{env.ENVIRONMENT}} );" >> local-config.php
 
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -131,5 +131,5 @@ jobs:
         run: |
           echo 'Deploying ${{env.GITHUB_REF}} to ${{env.ENVIRONMENT}}'
           git add -Av
-          git commit --allow-empty -m 'Deploying ${env.BRANCH_NAME} to ${env.ENVIRONMENT}'
+          git commit --allow-empty -m 'Deploying ${{env.BRANCH_NAME}} to ${{env.ENVIRONMENT}}'
           git push origin master

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
           php -r "file_exists( 'local-config.json' ) || copy( 'local-config-sample.json', 'local-config.json' );"
-          echo "define( 'WP_ENVIRONMENT_TYPE', ${{env.ENVIROMENT}} );" >> local-config.php
+          echo "define( 'WP_ENVIRONMENT_TYPE', ${{env.ENVIRONMENT}} );" >> local-config.php
 
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -131,5 +131,5 @@ jobs:
         run: |
           echo 'Deploying ${{env.GITHUB_REF}} to ${{env.ENVIRONMENT}}'
           git add -Av
-          git commit --allow-empty -m 'Deploying ${env.BRANCH_NAME} to ${env.ENVIRONMENT}'
+          git commit --allow-empty -m 'Deploying ${{env.BRANCH_NAME}} to ${{env.ENVIRONMENT}}'
           git push origin master

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.04
+* Fixed: deploy commit messages via GitHub actions now display the branch and environment instead of the variables.
 * Changed: all block models are now instantiated with the container to support dependency injection.
 
 ## 2022.03


### PR DESCRIPTION
## What does this do/fix?

- Display the actual branch and environment in git deploy git messages instead of `Deploying ${env.BRANCH_NAME} to ${env.ENVIRONMENT}`


## QA

- Reviewing GitHub action logs and commits in a deployed repo should display the proper branch and environment names and not their variables.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a GitHub action update.
- [ ] No, I need help figuring out how to write the tests.

