### PR TITLE
Feature/Discussion: ACF Maxlength Helper Function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.04
+* Added: An ACF helper class (`tribe-counter-wrapper`) that triggers a maxlength counter on the field.
 * Fixed: deploy commit messages via GitHub actions now display the branch and environment instead of the variables.
 * Changed: all block models are now instantiated with the container to support dependency injection.
 

--- a/dev/tests/tests/unit/Tribe/Project/Integrations/ACF/Max_Length_CounterTest.php
+++ b/dev/tests/tests/unit/Tribe/Project/Integrations/ACF/Max_Length_CounterTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace Tribe\Project\Integrations\ACF;
+
+use tad\FunctionMocker\FunctionMocker;
+
+class Max_Length_CounterTest extends \Codeception\Test\Unit {
+	/**
+	 * @var \UnitTester
+	 */
+	protected $tester;
+
+	protected function _setUpBeforeClass(): void {
+		FunctionMocker::setUp();
+		FunctionMocker::replace( 'esc_attr', static function ( $string ) {
+			return $string;
+		} );
+		FunctionMocker::replace( 'esc_html', static function ( $string ) {
+			return $string;
+		} );
+	}
+
+	protected function _before() {
+	}
+
+	protected function _after() {
+	}
+
+	/**
+     * @dataProvider fieldDataProvider
+     */
+    public function test_add_counter_div( $field, $expected ) {
+		$counter = new Max_Length_Counter();
+		$counter->add_counter_div( $field );
+		$output = $this->getActualOutput();
+		$this->assertEquals( $expected, $output );
+	}
+
+	public function fieldDataProvider() {
+		return [
+			'show counter with no value' => [
+				[
+					'wrapper' => [
+						'class' => Max_Length_Counter::MAX_LENGTH_COUNTER_WRAPPER_CLASS,
+					],
+					'maxlength' => '10',
+					'value' => '',
+				],
+				'<div class="textright ' . Max_Length_Counter::MAX_LENGTH_COUNTER_DIV_CLASS . '">0 / 10</div>'
+			],
+			'show counter with value length of 5' => [
+				[
+					'wrapper' => [
+						'class' => Max_Length_Counter::MAX_LENGTH_COUNTER_WRAPPER_CLASS,
+					],
+					'maxlength' => '10',
+					'value' => '12345',
+				],
+				'<div class="textright ' . Max_Length_Counter::MAX_LENGTH_COUNTER_DIV_CLASS . '">5 / 10</div>'
+			],
+			'no maxlength set' => [
+				[
+					'wrapper' => [
+						'class' => Max_Length_Counter::MAX_LENGTH_COUNTER_WRAPPER_CLASS,
+					],
+					'maxlength' => '',
+					'value' => '12345',
+				],
+				NULL
+			],
+			'no wrapper class set' => [
+				[
+					'wrapper' => [
+						'class' => '',
+					],
+					'maxlength' => '10',
+					'value' => '',
+				],
+				NULL
+			],
+			'wrapper class not included' => [
+				[
+					'wrapper' => [
+						'class' => 'cool-class another-cool-class',
+					],
+					'maxlength' => '10',
+					'value' => '',
+				],
+				NULL
+			],
+			'wrapper class with no maxlength' => [
+				[
+					'wrapper' => [
+						'class' => Max_Length_Counter::MAX_LENGTH_COUNTER_DIV_CLASS,
+					],
+					'maxlength' => '0',
+					'value' => '',
+				],
+				NULL
+			]
+		];
+	}
+}

--- a/wp-content/plugins/core/src/Core.php
+++ b/wp-content/plugins/core/src/Core.php
@@ -9,6 +9,7 @@ use Tribe\Project\Blocks\Blocks_Definer;
 use Tribe\Project\Blocks\Blocks_Subscriber;
 use Tribe\Project\Cache\Cache_Subscriber;
 use Tribe\Project\CLI\CLI_Definer;
+use Tribe\Project\Integrations\ACF\ACF_Subscriber;
 use Tribe\Project\Integrations\Google_Tag_Manager\Google_Tag_Manager_Subscriber;
 use Tribe\Project\Integrations\Gravity_Forms\Gravity_Forms_Subscriber;
 use Tribe\Project\Integrations\Yoast_SEO\Yoast_SEO_Subscriber;
@@ -52,6 +53,7 @@ class Core {
 	 * @var string[] Names of classes extending Abstract_Subscriber.
 	 */
 	private array $subscribers = [
+		ACF_Subscriber::class,
 		Admin_Subscriber::class,
 		Assets_Subscriber::class,
 		Blocks_Subscriber::class,

--- a/wp-content/plugins/core/src/Integrations/ACF/ACF_Subscriber.php
+++ b/wp-content/plugins/core/src/Integrations/ACF/ACF_Subscriber.php
@@ -8,7 +8,7 @@ class ACF_Subscriber extends Abstract_Subscriber {
 
 	public function register(): void {
 		add_action( 'acf/render_field', function ( $field ): void {
-			$this->container->get( Max_Length_Counter::class )->add_counter_div( $field );
+			$this->container->get( Max_Length_Counter::class )->add_counter_div( (array) $field );
 		} );
 
 		add_action( 'acf/input/admin_footer', function (): void {

--- a/wp-content/plugins/core/src/Integrations/ACF/ACF_Subscriber.php
+++ b/wp-content/plugins/core/src/Integrations/ACF/ACF_Subscriber.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Integrations\ACF;
+
+use Tribe\Libs\Container\Abstract_Subscriber;
+
+class ACF_Subscriber extends Abstract_Subscriber {
+
+	public function register(): void {
+		add_action( 'acf/render_field', function ( $field ): void {
+			$this->container->get( Max_Length_Counter::class )->add_counter_div( $field );
+		} );
+
+		add_action( 'acf/input/admin_footer', function (): void {
+			$this->container->get( Max_Length_Counter::class )->add_counter_js();
+		} );
+	}
+
+}

--- a/wp-content/plugins/core/src/Integrations/ACF/Max_Length_Counter.php
+++ b/wp-content/plugins/core/src/Integrations/ACF/Max_Length_Counter.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Integrations\ACF;
+
+class Max_Length_Counter {
+
+	public const MAX_LENGTH_COUNTER_WRAPPER_CLASS = 'tribe-counter-wrapper';
+	public const MAX_LENGTH_COUNTER_DIV_CLASS     = 'tribe-counter';
+
+	/**
+	 * Adds a div below any field that includes the self::MAX_LENGTH_COUNTER_WRAPPER_CLASS
+	 * in the field[wrapper][class] and has a maxlength of more than zero.
+	 *
+	 * @hook acf/render_field
+	 *
+	 * @param array $field The field array coming from ACF.
+	 */
+	public function add_counter_div( array $field ): void {
+		if ( ! isset( $field['wrapper'] ) || ! isset( $field['wrapper']['class'] ) ) {
+			return;
+		}
+
+		if ( ! isset( $field['maxlength'] ) || ! intval( $field['maxlength'] ) > 0 ) {
+			return;
+		}
+
+		if ( ! str_contains( $field['wrapper']['class'], self::MAX_LENGTH_COUNTER_WRAPPER_CLASS ) ) {
+			return;
+		}
+
+		echo sprintf(
+			'<div class="textright %s">%s / %s</div>',
+			esc_attr( self::MAX_LENGTH_COUNTER_DIV_CLASS ),
+			esc_html( (string) strlen( $field['value'] ) ),
+			esc_html( $field['maxlength'] )
+		);
+	}
+
+	/**
+	 * Outputs the javascript to the footer on admin pages that include ACF files
+	 * that increments that counter based on the value of the field.
+	 *
+	 * @hook acf/input/admin_footer
+	 */
+	public function add_counter_js(): void {
+		?>
+		<script type="text/javascript">
+			( function () {
+				document.addEventListener('click',function(e){
+					if ( e.target.matches( '.<?php echo esc_attr( self::MAX_LENGTH_COUNTER_WRAPPER_CLASS ); ?> input[maxlength]' ) || e.target.matches( '.<?php echo esc_attr( self::MAX_LENGTH_COUNTER_WRAPPER_CLASS ); ?> textarea[maxlength]' ) ) {
+						e.target.addEventListener( 'keyup', function( e ) {
+							var maxLength = e.target.getAttribute( 'maxlength' );
+							var counter   = e.target.closest( '.<?php echo esc_attr( self::MAX_LENGTH_COUNTER_WRAPPER_CLASS ); ?>' ).querySelector( '.<?php echo esc_attr( self::MAX_LENGTH_COUNTER_DIV_CLASS ); ?>' );
+							if ( counter ) {
+								counter.innerHTML = e.target.value.length + ' / ' + maxLength;
+							}
+						} );
+					}
+			   } );
+			} ) ( );
+		</script>
+		<?php
+	}
+
+}


### PR DESCRIPTION
## What does this do/fix?

Adds an ACF helper class that triggers a max character counter on input or textarea fields that include a maxlength value. For every project I have worked on, there has been a request for this feature and the level of discovery/lift always kept us from getting it added. 

I have included example usage in the video below.


## QA

Screenshots/video:
- [Link to Video](http://p.tri.be/4nsXJG)

## Tests

Does this have tests?

- [x] Yes
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

