### PR TITLE
Feature: Adds Recommended Extensions for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ pimple.json
 
 # IDE generated files #
 ######################
-.vscode
+.vscode/*
+!.vscode/extensions.json
 
 # Vim generated files #
 #######################

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,15 +1,15 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
         "EditorConfig.EditorConfig",
         "xdebug.php-debug",
         "valeryanm.vscode-phpsab"
-	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": [
 
-	]
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"EditorConfig.EditorConfig",
+        "xdebug.php-debug",
+        "valeryanm.vscode-phpsab"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
-		"EditorConfig.EditorConfig",
+        "EditorConfig.EditorConfig",
         "xdebug.php-debug",
         "valeryanm.vscode-phpsab"
 	],

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * Updated: Webpack & related configs for React HMR / Example react app dev.
 * Fixed: deploy commit messages via GitHub actions now display the branch and environment instead of the variables.
 * Changed: all block models are now instantiated with the container to support dependency injection.
+* Added: Recommended Extensions for VS Code.
 
 ## 2022.03
 * Fixed: Refactor index controller to use proper meta fetching objects and general code clean up.


### PR DESCRIPTION
## What does this do/fix?

Adds a popup to VSCode if you do not have the recommended extensions installed, suggesting that you install them. The recommended extensions are: 

- EditorConfig (for utilizing our editor config settings)
- xDebug (for debugging PHP)
- PHP Sniffer & Beautifier (for PHPCS)


## QA

Screenshots/video:
- [Screenshot of Recommended WorkSpace Extensions](http://p.tri.be/F0bg0K)

## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because it is a configuration tool.
- [ ] No, I need help figuring out how to write the tests.

