### PR TITLE
Bugfix/cssnano autoprefixer webkit box orient

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.04
+* Fixed: Remove autoprefixer run from cssnano task as it erroneously strips line-clamp properties.
 * Added: An ACF helper class (`tribe-counter-wrapper`) that triggers a maxlength counter on the field.
 * Added: node and composer caching for GitHub actions
 * Updated: Webpack & related configs for React HMR / Example react app dev.

--- a/gulp-tasks/cssnano.js
+++ b/gulp-tasks/cssnano.js
@@ -7,7 +7,7 @@ const pkg = require( '../package.json' );
 function minify( src = [], dest = pkg.square1.paths.core_admin_css_dist ) {
 	return gulp.src( src )
 		.pipe( sourcemaps.init() )
-		.pipe( cssnano( { zindex: false, discardUnused: { keyframes: false } } ) )
+		.pipe( cssnano( { autoprefixer: false, zindex: false, discardUnused: { keyframes: false } } ) )
 		.pipe( rename( {
 			suffix: '.min',
 			extname: '.css',


### PR DESCRIPTION
## What does this do/fix?

Don't run autoprefixer during cssnano task as it erroneously strips line-clamp properties. [Relevant slack convo.](https://tribe.slack.com/archives/C01CY7418GY/p1615393350109800?thread_ts=1615386015.104600&cid=C01CY7418GY)