### PR TITLE
Feature/autowired meta definer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.05
+* Updated: Ensure object meta definers are using autowiring for automatic dependency injection. 
 * Added: Brings in the [square1-field-models](https://github.com/moderntribe/square1-field-models) library.
 * Updated: WordPress to 5.9.3, ACF to 5.12.2 and Yoast to 18.8.
 * Fixed: Hides deprecation notices when running lefthook phpcs, which appear if you're running PHP8.1 locally.

--- a/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
+++ b/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
@@ -45,8 +45,11 @@ class Object_Meta_Definer implements Definer_Interface {
 				] ),
 
 			Taxonomy_Archive_Settings::class                    => DI\autowire()
-				->constructorParameter( 'object_types', static fn( ContainerInterface $c ) => [
-					'taxonomies' => [ Category::NAME, Post_Tag::NAME ],
+				->constructorParameter( 'object_types', static fn() => [
+					'taxonomies' => [
+						Category::NAME,
+						Post_Tag::NAME,
+					],
 				] ),
 		];
 	}

--- a/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
+++ b/wp-content/plugins/core/src/Object_Meta/Object_Meta_Definer.php
@@ -23,36 +23,31 @@ class Object_Meta_Definer implements Definer_Interface {
 			] ),
 
 			// add analytics settings to the general settings screen
-			Analytics_Settings::class                           => static function ( ContainerInterface $container ) {
-				return new Analytics_Settings( [
-					'settings_pages' => [ $container->get( Settings\General::class )->get_slug() ],
-				] );
-			},
+			Analytics_Settings::class                           => DI\autowire()
+				->constructorParameter( 'object_types', static fn( ContainerInterface $c ) => [
+					'settings_pages' => [ $c->get( Settings\General::class )->get_slug() ],
+				] ),
 
 			// add social settings to the general settings screen
-			Social_Settings::class                              => static function ( ContainerInterface $container ) {
-				return new Social_Settings( [
-					'settings_pages' => [ $container->get( Settings\General::class )->get_slug() ],
-				] );
-			},
+			Social_Settings::class                              => DI\autowire()
+				->constructorParameter( 'object_types', static fn( ContainerInterface $c ) => [
+					'settings_pages' => [ $c->get( Settings\General::class )->get_slug() ],
+				] ),
 
-			Post_Archive_Featured_Settings::class               => static function ( ContainerInterface $container ) {
-				return new Post_Archive_Featured_Settings( [
-					'settings_pages' => [ $container->get( Settings\Post_Settings::class )->get_slug() ],
-				] );
-			},
+			Post_Archive_Featured_Settings::class               => DI\autowire()
+				->constructorParameter( 'object_types', static fn( ContainerInterface $c ) => [
+					'settings_pages' => [ $c->get( Settings\Post_Settings::class )->get_slug() ],
+				] ),
 
-			Post_Archive_Settings::class                        => static function ( ContainerInterface $container ) {
-				return new Post_Archive_Settings( [
-					'settings_pages' => [ $container->get( Settings\Post_Settings::class )->get_slug() ],
-				] );
-			},
+			Post_Archive_Settings::class                        => DI\autowire()
+				->constructorParameter( 'object_types', static fn( ContainerInterface $c ) => [
+					'settings_pages' => [ $c->get( Settings\Post_Settings::class )->get_slug() ],
+				] ),
 
-			Taxonomy_Archive_Settings::class                    => static function (): Taxonomy_Archive_Settings {
-				return new Taxonomy_Archive_Settings( [
+			Taxonomy_Archive_Settings::class                    => DI\autowire()
+				->constructorParameter( 'object_types', static fn( ContainerInterface $c ) => [
 					'taxonomies' => [ Category::NAME, Post_Tag::NAME ],
-				] );
-			},
+				] ),
 		];
 	}
 


### PR DESCRIPTION
## What does this do/fix?

- Use autowiring for object meta definers so we can use automatic dependency injection in the constructor.

## QA

- Should work exactly as before, but now you can auto inject instances into object meta classes.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's just a DI definition update.
- [ ] No, I need help figuring out how to write the tests.

