### PR TITLE
Bugfix/node deploy cache

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           node-version-file: "${{ env.BUILD_FOLDER }}/.nvmrc"
           cache: 'yarn'
+          cache-dependency-path: "${{ env.BUILD_FOLDER }}/yarn.lock"
 
       # Yarn Install and Build
       - name: Yarn install and build

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           node-version-file: "${{ env.BUILD_FOLDER }}/.nvmrc"
           cache: 'yarn'
+          cache-dependency-path: "${{ env.BUILD_FOLDER }}/yarn.lock"
 
       # Yarn Install and Build
       - name: Yarn install and build

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           node-version-file: "${{ env.BUILD_FOLDER }}/.nvmrc"
           cache: 'yarn'
+          cache-dependency-path: "${{ env.BUILD_FOLDER }}/yarn.lock"
 
       # Yarn Install and Build
       - name: Yarn install and build

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.05
+* Fixed: Ensure setup-node github action can find the yarn.lock file for caching.
 * Added: Brings in the [square1-field-models](https://github.com/moderntribe/square1-field-models) library.
 * Updated: WordPress to 5.9.3, ACF to 5.12.2 and Yoast to 18.8.
 * Fixed: Hides deprecation notices when running lefthook phpcs, which appear if you're running PHP8.1 locally.


### PR DESCRIPTION
## What does this do/fix?

- Deploys are broken because the `setup-node` action can't find the `yarn.lock `file because we clone the repo into a custom folder. This tells the action where to look for the `yarn.lock` file.

## QA

- Deploys work again.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a GitHub action update.
- [ ] No, I need help figuring out how to write the tests.

