### PR TITLE
Update phpstorm.meta docs to include `make()` method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.05
+* Updated: `.phpstorm.meta.php` code completion documentation.
 * Added: Brings in the [square1-field-models](https://github.com/moderntribe/square1-field-models) library.
 * Updated: WordPress to 5.9.3, ACF to 5.12.2 and Yoast to 18.8.
 * Fixed: Hides deprecation notices when running lefthook phpcs, which appear if you're running PHP8.1 locally.

--- a/docs/concepts/container.md
+++ b/docs/concepts/container.md
@@ -153,15 +153,24 @@ like `foo.bar`.
 
 
 ```php
-<?php
+<?php declare(strict_types=1);
+
 // .phpstorm.meta.php
-namespace PHPSTORM_META
-{
-    override(\Psr\Container\ContainerInterface::get(0), map([
-        '' => '@',
-    ]));
-    override(\DI\Container::get(0), map([
-        '' => '@',
-    ]));
+namespace PHPSTORM_META {
+
+	override( \Psr\Container\ContainerInterface::get( 0 ), map( [
+		'' => '@',
+	] ) );
+	override( \DI\Container::get( 0 ), map( [
+		'' => '@',
+	] ) );
+	override( \DI\FactoryInterface::make( 0 ), map( [
+		'' => '@',
+	] ) );
+	override( \DI\Container::make( 0 ), map( [
+		'' => '@',
+	] ) );
 }
 ```
+
+> NOTE: Vscode users can also use the file above with the [PHP Intelephense extension](https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client) installed.


### PR DESCRIPTION
## What does this do/fix?

- Updates documentation to improve PHP-DI container code completion using the `.phpstorm.meta.php` file.

## QA

Tested in vscodium (not code):

![image](https://user-images.githubusercontent.com/1066195/169396224-c657c591-3718-44ef-8747-2da5f12b4f59.png)


## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a documentation update.
- [ ] No, I need help figuring out how to write the tests.

