### PR TITLE
Adds PHP Intelephese to Recoomended VS Code extentions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
     "recommendations": [
         "EditorConfig.EditorConfig",
         "xdebug.php-debug",
-        "valeryanm.vscode-phpsab"
+        "valeryanm.vscode-phpsab",
+        "bmewburn.vscode-intelephense-client"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": [

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.05
+* Updated: Recommended extentions for VS Code to include PHP Intelephense. 
 * Added: Brings in the [square1-field-models](https://github.com/moderntribe/square1-field-models) library.
 * Updated: WordPress to 5.9.3, ACF to 5.12.2 and Yoast to 18.8.
 * Fixed: Hides deprecation notices when running lefthook phpcs, which appear if you're running PHP8.1 locally.


### PR DESCRIPTION
## What does this do/fix?

Adds the PHP Intelephese VS Code extension to allow for PHPStorm Metadata autocompletion.  This also helps with compatibility between IDE's in #987. 


## QA

Screenshots/video:
- [Screenshot](http://p.tri.be/mjxoAQ)

## Tests

Does this have tests?

- [ ] Yes
- [X] No, this doesn't need tests because it is an IDE setting.
- [ ] No, I need help figuring out how to write the tests.

