### PR TITLE
Set up the container for use in integration tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.05
+* Added: Access to the container in integration tests via `$this->container`.
 * Updated: Recommended extentions for VS Code to include PHP Intelephense. 
 * Updated: `.phpstorm.meta.php` code completion documentation.
 * Fixed: Ensure setup-node github action can find the yarn.lock file for caching.

--- a/dev/tests/tests/_support/Classes/Test_Case.php
+++ b/dev/tests/tests/_support/Classes/Test_Case.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tribe\Tests;
 
@@ -8,7 +8,22 @@ use Codeception\TestCase\WPTestCase;
  * Class Test_Case
  * Test case with specific actions for Square One projects.
  *
+ * @mixin \Codeception\Test\Unit
+ * @mixin \PHPUnit\Framework\TestCase
+ *
  * @package Tribe\Tests
  */
 class Test_Case extends WPTestCase {
+
+	/**
+	 * @var \DI\FactoryInterface|\Invoker\InvokerInterface|\Psr\Container\ContainerInterface
+	 */
+	protected $container;
+
+	public function _setUp() {
+		parent::_setUp();
+
+		$this->container = tribe_project()->container();
+	}
+
 }


### PR DESCRIPTION
## What does this do/fix?

- Allows the use of `$this->container->get( Whatever::class )` for integration tests. Sometimes you want to actually test the class as the container builds it instead of creating the dependencies manually.

## QA

- Should function exactly as before.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's updating the test framework itself!
- [ ] No, I need help figuring out how to write the tests.

