### PR TITLE
Allow unlimited memory when running PHPStan via CI

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -89,4 +89,4 @@ jobs:
 
       - name: Static Analysis
         if: ${{ steps.filter.outputs.wpcontent == 'true' }}
-        run: ./vendor/bin/phpstan --memory-limit=512M
+        run: ./vendor/bin/phpstan --memory-limit=-1

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.05
-* Updated: Recommended extentions for VS Code to include PHP Intelephense. 
+* Fixed: Prevent PHPStan from running out of memory during CI runs.
+* Updated: Recommended extensions for VS Code to include PHP Intelephense. 
 * Updated: `.phpstorm.meta.php` code completion documentation.
 * Fixed: Ensure setup-node github action can find the yarn.lock file for caching.
 * Updated: Ensure object meta definers are using autowiring for automatic dependency injection. 


### PR DESCRIPTION
## What does this do/fix?

- Allows PHPStan to use unlimited memory, at a certain number of files it will always run out and throw errors.

## QA

- No more failing CI.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a CI update.
- [ ] No, I need help figuring out how to write the tests.

