### PR TITLE
fix update query var utility; add tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2022.06
+* Fixed: `update-query-var.js` can now properly remove keys with `undefined` values.
+
 ## 2022.05
 * Updated: Recommended extentions for VS Code to include PHP Intelephense. 
 * Updated: `.phpstorm.meta.php` code completion documentation.

--- a/wp-content/themes/core/assets/js/src/utils/data/update-query-var.js
+++ b/wp-content/themes/core/assets/js/src/utils/data/update-query-var.js
@@ -1,26 +1,43 @@
-function updateQueryVar( key, value, url = window.location.href ) {
-	const separator = '?';
+/**
+ * @function updateQueryVar
+ *
+ * @description update the query string based on a key/value pair given
+ *
+ * @param string key
+ * @param string value
+ * @param string url (optional)
+ *
+ * @returns string
+ */
+const updateQueryVar = ( key, value, url = window.location.href ) => {
+	const re = new RegExp( `([?&])${ key }=.*?(&|#|$)(.*)`, 'gi' );
 
-	const hashSplit = url.split( '#' );
-	const hash = hashSplit[ 1 ] ? `#${ hashSplit[ 1 ] }` : '';
-	const querySplit = hashSplit[ 0 ].split( '?' );
-	const host = querySplit[ 0 ];
-	const query = querySplit[ 1 ];
-	const params = query !== undefined ? query.split( '&' ) : [];
-	let updated = false;
+	let hash;
+	let separator;
+	let parsedUrl = url;
 
-	params.forEach( ( item, index ) => {
-		if ( item.startsWith( `${ key }=` ) ) {
-			updated = true;
-			params[ index ] = `${ key }=${ value }`;
+	if ( re.test( url ) ) {
+		if ( typeof value !== 'undefined' && value !== null ) {
+			parsedUrl = url.replace( re, `$1${ key }=${ value }$2$3` );
+		} else {
+			hash = url.split( '#' );
+			parsedUrl = hash[ 0 ].replace( re, '$1$3' ).replace( /(&|\?)$/, '' );
+
+			if ( typeof hash[ 1 ] !== 'undefined' && hash[ 1 ] !== null ) {
+				parsedUrl += `#${ hash[ 1 ] }`;
+			}
 		}
-	} );
+	} else if ( typeof value !== 'undefined' && value !== null ) {
+		separator = url.indexOf( '?' ) !== -1 ? '&' : '?';
+		hash = url.split( '#' );
+		parsedUrl = `${ hash[ 0 ] }${ separator }${ key }=${ value }`;
 
-	if ( ! updated ) {
-		params[ params.length ] = `${ key }=${ value }`;
+		if ( typeof hash[ 1 ] !== 'undefined' && hash[ 1 ] !== null ) {
+			parsedUrl += `#${ hash[ 1 ] }`;
+		}
 	}
 
-	return `${ host }${ separator }${ params.join( '&' ) }${ hash }`;
-}
+	return parsedUrl;
+};
 
 export default updateQueryVar;

--- a/wp-content/themes/core/assets/js/test/tests/utils/data/update-query-var.test.js
+++ b/wp-content/themes/core/assets/js/test/tests/utils/data/update-query-var.test.js
@@ -1,3 +1,4 @@
+import expect from 'expect';
 import updateQueryVar from 'utils/data/update-query-var';
 
 describe( 'updateQueryVar', () => {
@@ -27,6 +28,24 @@ describe( 'updateQueryVar', () => {
 		const key = 'param1';
 		const value = 'false';
 		const expectedUrl = 'http://localhost/?param1=false#hash';
+
+		expect( updateQueryVar( key, value, url ) ).toBe( expectedUrl );
+	} );
+
+	it( 'remove a key that has been set to undefined', () => {
+		const url = 'http://localhost/?param1=true&param2=1024';
+		const key = 'param1';
+		const value = undefined;
+		const expectedUrl = 'http://localhost/?param2=1024';
+
+		expect( updateQueryVar( key, value, url ) ).toBe( expectedUrl );
+	} );
+
+	it ( 'do not add a key that is set to undefined', () => {
+		const url = 'http://localhost/';
+		const key = 'param1';
+		const value = undefined;
+		const expectedUrl = 'http://localhost/';
 
 		expect( updateQueryVar( key, value, url ) ).toBe( expectedUrl );
 	} );

--- a/wp-content/themes/core/assets/js/test/tests/utils/data/update-query-var.test.js
+++ b/wp-content/themes/core/assets/js/test/tests/utils/data/update-query-var.test.js
@@ -41,7 +41,7 @@ describe( 'updateQueryVar', () => {
 		expect( updateQueryVar( key, value, url ) ).toBe( expectedUrl );
 	} );
 
-	it ( 'do not add a key that is set to undefined', () => {
+	it( 'do not add a key that is set to undefined', () => {
 		const url = 'http://localhost/';
 		const key = 'param1';
 		const value = undefined;


### PR DESCRIPTION
## What does this do/fix?

The `updateQueryVar` utility was not properly removing query vars set to `undefined`. This fix pulls in a version of `updateQueryVar` that adds all necessary functionality. This fix also includes tests for query vars that have an `undefined` value.

## Tests

Does this have tests?

- [x] Yes, tests have been updated accordingly to match new functionality. It's possible it need a few more though to test for null values as well. Let me know if we need those as well and I can get them added in.
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

