### PR TITLE
Improvement: remove stats block redundant constant

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Fixed: Remove `SECTION_CONTENT` constant from `Stats Block`.
 * Fixed: Blocks added below floated elements in Gutenberg should now properly clear on both the frontend and backend.
 * Fixed: Gravity Forms spin.js spinner should now properly work for paginated forms.
 * Added: [phpstan/phpstan-mockery](https://github.com/phpstan/phpstan-mockery)

--- a/wp-content/plugins/core/src/Blocks/Types/Stats/Stats.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Stats/Stats.php
@@ -17,10 +17,9 @@ class Stats extends Block_Config implements Cta_Field {
 
 	public const NAME = 'stats';
 
-	public const SECTION_CONTENT = 's-content';
-	public const LEAD_IN         = 'leadin';
-	public const TITLE           = 'title';
-	public const DESCRIPTION     = 'description';
+	public const LEAD_IN     = 'leadin';
+	public const TITLE       = 'title';
+	public const DESCRIPTION = 'description';
 
 	public const LAYOUT         = 'layout';
 	public const LAYOUT_INLINE  = 'inline';


### PR DESCRIPTION
## What does this do/fix?

- Removes redundant `SECTION_CONTENT` constant in Stats Block

## QA

N/A

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because the removed constant was redundant
- [ ] No, I need help figuring out how to write the tests.

