### PR TITLE
add phpstan/phpstan-mockery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Added: [phpstan/phpstan-mockery](https://github.com/phpstan/phpstan-mockery)
 * Fixed: Tab block controller throwing type errors.
 * Fixed: `update-query-var.js` can now properly remove keys with `undefined` values.
 

--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
     "php-stubs/wordpress-tests-stubs": "^5.8",
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.5",
+    "phpstan/phpstan-mockery": "^1.1",
     "phpunit/phpunit": "^8.0 || ^9.0 <9.5",
     "szepeviktor/phpstan-wordpress": "^1.0",
     "wp-cli/wp-cli": "^2.5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e906f804c7326ab8799f0dec24a81d0",
+    "content-hash": "2fefb352aa954382784320a78b86bcf8",
     "packages": [
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
@@ -6962,6 +6962,56 @@
                 }
             ],
             "time": "2022-05-10T06:54:21+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-mockery",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-mockery.git",
+                "reference": "245b17ccd00f04be3c6b9fc6645f63793b37b2ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/245b17ccd00f04be3c6b9fc6645f63793b37b2ea",
+                "reference": "245b17ccd00f04be3c6b9fc6645f63793b37b2ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.5.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2.4",
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan Mockery extension",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-mockery/issues",
+                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.0"
+            },
+            "time": "2022-05-09T13:12:35+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
## What does this do/fix?

- Adds https://github.com/phpstan/phpstan-mockery to stop PHPStan from complaining when using mocks in tests.


## QA

PHPStan will no longer complain about mocked types in tests, e.g.

```php
<?php declare(strict_types=1);

namespace Tribe\Project\Blocks\Middleware\Color_Theme;

use Mockery;
use Tribe\Project\Prefixer;
use Tribe\Tests\Test_Case;

final class MyTest extends Test_Case {

	/**
	 * @var \Tribe\Project\Prefixer|\Mockery\MockInterface
	 */
	private $prefixer;

	public function _setUp() {
		parent::_setUp();

		$this->prefixer = Mockery::mock( Prefixer::class );
	}

	public function test_it_prefixes_with_a_string(): void {
		$this->prefixer->shouldReceive( 'prefix' )
		               ->once()
		               ->with( 'custom_prefix_' )
		               ->andReturn( 'custom_prefix_test_string' );

		$this->assertSame( 'custom_prefix_test_string', ( new String_Prefixer( $this->prefixer ) )->prefix( 'test_string' ) );
	}

}
```

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because its a test dependency
- [ ] No, I need help figuring out how to write the tests.

