### PR TITLE
[SQONE-574]: clear floats on all blocks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Fixed: Blocks added below floated elements in Gutenberg should now properly clear on both the frontend and backend.
 * Fixed: Tab block controller throwing type errors.
 * Fixed: `update-query-var.js` can now properly remove keys with `undefined` values.
 

--- a/wp-content/themes/core/components/blocks/_css/block-editor.pcss
+++ b/wp-content/themes/core/components/blocks/_css/block-editor.pcss
@@ -9,6 +9,7 @@
 .wp-block[data-type^="acf/"] {
 	max-width: none;
 	width: 100%;
+	clear: both;
 
 	/* Add a max-width to the edit UI for ACF blocks */
 	.acf-block-fields {

--- a/wp-content/themes/core/components/blocks/_css/index.pcss
+++ b/wp-content/themes/core/components/blocks/_css/index.pcss
@@ -11,6 +11,7 @@
 .c-block {
 	margin-top: var(--spacer-60);
 	margin-bottom: var(--spacer-60);
+	clear: both;
 
 	@media (--viewport-medium) {
 		margin-top: var(--spacer-80);


### PR DESCRIPTION
## What does this do/fix?

https://moderntribe.atlassian.net/browse/SQONE-574

Blocks on both the front end & back end weren't properly being cleared around floated elements. Since all of our blocks are made to be full width, we can safely add `clear: both;` to all of our blocks.

(sorry about the commit having the wrong ticket tag, that's my bad)

## QA

1. Add a floated element
2. Add a SO block below the floated element, this block shouldn't float up beside the floated element.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's styling.
- [ ] No, I need help figuring out how to write the tests.

