### PR TITLE
[SQONE-582]: fix spinner not spinning issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Fixed: Gravity Forms spin.js spinner should now properly work for paginated forms.
 * Added: [phpstan/phpstan-mockery](https://github.com/phpstan/phpstan-mockery)
 * Fixed: Tab block controller throwing type errors.
 * Fixed: `update-query-var.js` can now properly remove keys with `undefined` values.

--- a/wp-content/themes/core/integrations/gravity-forms/css/spinner.pcss
+++ b/wp-content/themes/core/integrations/gravity-forms/css/spinner.pcss
@@ -15,7 +15,8 @@
 	}
 }
 
-.gform_footer {
+.gform_footer,
+.gform_page_footer {
 	position: relative;
 
 	@media (--viewport-medium) {

--- a/wp-content/themes/core/integrations/gravity-forms/js/gravity-forms.js
+++ b/wp-content/themes/core/integrations/gravity-forms/js/gravity-forms.js
@@ -85,6 +85,8 @@ const bindEvents = () => {
 		.on( 'gform_confirmation_loaded', gravityFormConfirmationLoaded );
 
 	delegate( el.container, '.gform_button', 'click', spinOn );
+	delegate( el.container, '.gform_next_button', 'click', spinOn );
+	delegate( el.container, '.gform_previous_button', 'click', spinOn );
 };
 
 /**


### PR DESCRIPTION
## What does this do/fix?

https://moderntribe.atlassian.net/browse/SQONE-582

The Gravity Forms spinner wasn't working for paginated forms. This PR addresses this by adding a relative position for the `gform_page_footer` classes as well as 2 new actions that call the `spinOn` method on the `.gform_next_button` and `.gform_previous_button` classes.

## QA

1. Create a paginated form in Gravity Forms and add it to a page/post.
2. Turn on AJAX for the form
3. Click previous/next buttons as well as the submit button and you should see the spinner to the right of the buttons with every click of the buttons.
5. ???
6. Profit!

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's styling & interaction based
- [ ] No, I need help figuring out how to write the tests.

