### PR TITLE
Feature/sqone 575/text alignment classes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Added: Text alignment mixins & classes to support Gutenberg.
 * Fixed: Remove `SECTION_CONTENT` constant from `Stats Block`.
 * Fixed: Blocks added below floated elements in Gutenberg should now properly clear on both the frontend and backend.
 * Fixed: Gravity Forms spin.js spinner should now properly work for paginated forms.

--- a/wp-content/themes/core/assets/css/src/theme/typography/_mixins.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/typography/_mixins.pcss
@@ -224,3 +224,23 @@
 	font-size: 13px;
 	letter-spacing: 0.5px;
 }
+
+/* -------------------------------------------------------------------------
+ * Text Alignment
+ * ------------------------------------------------------------------------- */
+
+@define-mixin t-ta-left {
+	text-align: left;
+}
+
+@define-mixin t-ta-center {
+	text-align: center;
+}
+
+@define-mixin t-ta-right {
+	text-align: right;
+}
+
+@define-mixin t-ta-justify {
+	text-align: justify;
+}

--- a/wp-content/themes/core/assets/css/src/theme/typography/_utilities.pcss
+++ b/wp-content/themes/core/assets/css/src/theme/typography/_utilities.pcss
@@ -139,3 +139,28 @@
 .t-tag {
 	@mixin t-tag;
 }
+
+/* -------------------------------------------------------------------------
+ * Text Alignment
+ * ------------------------------------------------------------------------- */
+
+.t-ta-center,
+.has-text-align-center {
+	@mixin t-ta-center;
+}
+
+.t-ta-right,
+.has-text-align-right {
+	@mixin t-ta-right;
+}
+
+.t-ta-left,
+.has-text-align-left {
+	@mixin t-ta-left;
+}
+
+.t-ta-justify,
+.has-text-align-justify {
+	@mixin t-ta-justify;
+}
+


### PR DESCRIPTION
## What does this do/fix?

Adds text alignment mixins & classes to support Gutenberg and non-Gutenberg text alignment needs.

From the looks of it, we already support media alignment in S1 and from my testing, it appears that we are currently targeting all the correct alignment classes. It doesn't appear that those have changed. I wasn't able to find any indication that they have changed either. Maybe I'm just not using the correct blocks?

## QA

Links to relevant issues
- [Text alignment classes have changed in Gutenberg](https://moderntribe.atlassian.net/browse/SQONE-575)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's styling.
- [ ] No, I need help figuring out how to write the tests.

