### PR TITLE
Bugfix: Prevent empty social items

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Fixed: Filter Social items to prevent empty HTML output.
 * Fixed: Remove `SECTION_CONTENT` constant from `Stats Block`.
 * Fixed: Blocks added below floated elements in Gutenberg should now properly clear on both the frontend and backend.
 * Fixed: Gravity Forms spin.js spinner should now properly work for paginated forms.

--- a/wp-content/themes/core/components/follow/Follow_Controller.php
+++ b/wp-content/themes/core/components/follow/Follow_Controller.php
@@ -31,7 +31,7 @@ class Follow_Controller extends Abstract_Controller {
 	}
 
 	public function get_social_links(): Social_Link_Collection {
-		$links = array_map( function ( $social_site ) {
+		$links = array_filter( array_map( function ( $social_site ) {
 			$url = $this->settings->get_setting( $social_site );
 
 			if ( ! $url ) {
@@ -44,7 +44,7 @@ class Follow_Controller extends Abstract_Controller {
 			$link->class = $social_site;
 
 			return $link->toArray();
-		}, $this->social_keys );
+		}, $this->social_keys ) );
 
 		return Social_Link_Collection::create( $links );
 	}


### PR DESCRIPTION
## What does this do/fix?

Filters empty social items to prevent empty HTML output


## QA

<img width="572" alt="Screenshot 2022-06-20 at 17 38 17" src="https://user-images.githubusercontent.com/33621842/174637051-9a616537-1d13-40c3-8afb-6bb6e6aa63ae.png">

VS.

<img width="528" alt="Screenshot 2022-06-20 at 17 38 41" src="https://user-images.githubusercontent.com/33621842/174637046-690b817f-b389-45bc-8bce-38171eb26319.png">

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests
- [ ] No, I need help figuring out how to write the tests.

