### PR TITLE
Feature: unregister block styles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Added: PHP side functionality and filter for unregistering block styles.
 * Fixed: Replaces `__()` with `esc_html__()` in `wp-content/plugins/core/src/Blocks` folder
 * Added: Text alignment mixins & classes to support Gutenberg.
 * Fixed: Filter Social items to prevent empty HTML output.

--- a/docs/basics/blocks.md
+++ b/docs/basics/blocks.md
@@ -5,7 +5,7 @@
 WordPress core (and some other plugins) provide a large collection of blocks to get us started.
 We'll often want to configure these block to match the nuances of a particular project.
 
-### Adding Block Types
+### Removing Block Types
 
 There are some block types that should be removed from the editor. Some reasons include:
 
@@ -13,10 +13,22 @@ There are some block types that should be removed from the editor. Some reasons 
 * Blocks that we have replaced with custom block types
 
 You can remove blocks by adding the block name to the `\Tribe\Project\Blocks\Blocks_Definer::DENY_LIST`
-array. Some care should be taken to avoid errors when WordPress uses nested block types. For example,
+array or by filtering it with `tribe/project/blocks/denylist` filter.
+Some care should be taken to avoid errors when WordPress uses nested block types. For example,
 removing the `core/button` block will trigger an error in the editor, because the `core/buttons`
 block expects it to be available. They must be removed together. Welcome to the world of nested
 components :)
+
+### Removing Block Styles
+
+To remove specific core block styles from editor add the records to the `\Tribe\Project\Blocks\Blocks_Definer::DENY_BLOCK_STYLES` like this:
+```php
+self::DENY_BLOCK_STYLES => [
+    'core/separator' => [ 'default', 'wide', 'line', 'dots' ],
+]
+```
+
+You can also filter the list of blocks and styles to unregister with the help of `tribe/project/blocks/style_denylist` filter.
 
 ### Configuring Block Options
 

--- a/docs/basics/blocks.md
+++ b/docs/basics/blocks.md
@@ -21,14 +21,19 @@ components :)
 
 ### Removing Block Styles
 
-To remove specific core block styles from editor add the records to the `\Tribe\Project\Blocks\Blocks_Definer::DENY_BLOCK_STYLES` like this:
+To remove specific core block styles from the editor, add the styles to the `\Tribe\Project\Blocks\Blocks_Definer::DENY_BLOCK_STYLES` like this:
 ```php
 self::DENY_BLOCK_STYLES => [
-    'core/separator' => [ 'default', 'wide', 'line', 'dots' ],
+    'core/separator' => [ 
+        'default', 
+        'wide', 
+        'line', 
+        'dots', 
+    ],
 ]
 ```
 
-You can also filter the list of blocks and styles to unregister with the help of `tribe/project/blocks/style_denylist` filter.
+You can also filter the list of blocks and styles to unregister with the help of the `tribe/project/blocks/style_denylist` filter.
 
 ### Configuring Block Options
 

--- a/wp-content/plugins/core/src/Assets/Admin/JS_Config.php
+++ b/wp-content/plugins/core/src/Assets/Admin/JS_Config.php
@@ -12,8 +12,9 @@ class JS_Config {
 	public function get_data(): array {
 		if ( ! isset( $this->data ) ) {
 			$this->data = [
-				'images_url'     => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/admin/',
-				'block_denylist' => (array) apply_filters( 'tribe/project/blocks/denylist', [] ),
+				'images_url'           => trailingslashit( get_stylesheet_directory_uri() ) . 'assets/img/admin/',
+				'block_denylist'       => (array) apply_filters( 'tribe/project/blocks/denylist', [] ),
+				'block_style_denylist' => (array) apply_filters( 'tribe/project/blocks/style_denylist', [] ),
 			];
 
 			$this->data = (array) apply_filters( 'core_admin_js_config', $this->data );

--- a/wp-content/plugins/core/src/Blocks/Block_Style_Deny_List.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Style_Deny_List.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Blocks;
+
+/**
+ * Class Block_Style_Deny_List
+ *
+ * Provides an array of block names together with styles to remove from the editor.
+ */
+class Block_Style_Deny_List {
+
+	/**
+	 * @var array<string, string[]> An array of default block type as key and an array of it styles to unregister.
+	 */
+	private array $style_denylist;
+
+	/**
+	 * @param array<string, string[]> $style_denylist
+	 */
+	public function __construct( array $style_denylist = [] ) {
+		$this->style_denylist = $style_denylist;
+	}
+
+	/**
+	 * Adds block type and it styles to the deny list to disable it in the block editor.
+	 *
+	 * @param array<string, string[]> $block_styles
+	 *
+	 * @return array<string, string[]>
+	 *
+	 * @filter tribe/project/blocks/style_denylist
+	 */
+	public function filter_block_style_denylist( array $block_styles = [] ): array {
+		return array_merge( $block_styles, $this->style_denylist );
+	}
+
+}

--- a/wp-content/plugins/core/src/Blocks/Block_Style_Deny_List.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Style_Deny_List.php
@@ -5,12 +5,14 @@ namespace Tribe\Project\Blocks;
 /**
  * Class Block_Style_Deny_List
  *
- * Provides an array of block names together with styles to remove from the editor.
+ * Removes block styles from the block specified as the array key.
+ *
+ * @link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
  */
 class Block_Style_Deny_List {
 
 	/**
-	 * @var array<string, string[]> An array of default block type as key and an array of it styles to unregister.
+	 * @var array<string, string[]>
 	 */
 	private array $style_denylist;
 
@@ -24,11 +26,11 @@ class Block_Style_Deny_List {
 	/**
 	 * Adds block type and it styles to the deny list to disable it in the block editor.
 	 *
+	 * @filter tribe/project/blocks/style_denylist
+	 *
 	 * @param array<string, string[]> $block_styles
 	 *
 	 * @return array<string, string[]>
-	 *
-	 * @filter tribe/project/blocks/style_denylist
 	 */
 	public function filter_block_style_denylist( array $block_styles = [] ): array {
 		return array_merge( $block_styles, $this->style_denylist );

--- a/wp-content/plugins/core/src/Blocks/Block_Style_Override.php
+++ b/wp-content/plugins/core/src/Blocks/Block_Style_Override.php
@@ -17,21 +17,14 @@ class Block_Style_Override {
 	protected array $register = [];
 
 	/**
-	 * @var string[][] The styles to unregister.
-	 */
-	protected array $unregister = [];
-
-	/**
 	 * Block_Style_Override constructor.
 	 *
 	 * @param string[]   $block_types
 	 * @param string[][] $register
-	 * @param string[][] $unregister
 	 */
-	public function __construct( array $block_types, array $register = [], array $unregister = [] ) {
+	public function __construct( array $block_types, array $register = [] ) {
 		$this->block_types = $block_types;
 		$this->register    = $register;
-		$this->unregister  = $unregister;
 	}
 
 	/**
@@ -41,10 +34,6 @@ class Block_Style_Override {
 		foreach ( $this->block_types as $type ) {
 			foreach ( $this->register as $style ) {
 				register_block_style( $type, $style );
-			}
-
-			foreach ( $this->unregister as $handle ) {
-				unregister_block_style( $type, $handle );
 			}
 		}
 	}

--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -92,9 +92,10 @@ class Blocks_Definer implements Definer_Interface {
 			 * @see https://github.com/moderntribe/square-one/blob/main/docs/basics/blocks.md#configuring-block-options
 			 */
 			self::DENY_BLOCK_STYLES      => [
-				'core/image'     => [ 'rounded', 'default' ],
-				'core/quote'     => [ 'plain', 'large', 'default' ],
-				'core/separator' => [ 'default', 'wide', 'line', 'dots' ],
+				'core/image' => [
+					'rounded',
+					'default',
+				],
 			],
 
 			/**

--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -26,13 +26,14 @@ use Tribe\Project\Blocks\Types\Tabs\Tabs;
 
 class Blocks_Definer implements Definer_Interface {
 
-	public const DENY_LIST = 'blocks.deny_list';
-	public const STYLES    = 'blocks.style_overrides';
-	public const TYPES     = 'blocks.types';
+	public const DENY_LIST         = 'blocks.deny_list';
+	public const DENY_BLOCK_STYLES = 'blocks.deny_block_styles';
+	public const STYLES            = 'blocks.style_overrides';
+	public const TYPES             = 'blocks.types';
 
 	public function define(): array {
 		return [
-			self::TYPES            => DI\add( [
+			self::TYPES                  => DI\add( [
 				DI\get( Accordion::class ),
 				DI\get( Buttons::class ),
 				DI\get( Card_Grid::class ),
@@ -60,7 +61,7 @@ class Blocks_Definer implements Definer_Interface {
 			 *
 			 * @see: https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#using-a-deny-list
 			 */
-			self::DENY_LIST        => [
+			self::DENY_LIST              => [
 				'core/archives',
 				'core/button',
 				'core/buttons',
@@ -84,13 +85,26 @@ class Blocks_Definer implements Definer_Interface {
 			],
 
 			/**
+			 * An array of default block type as key and an array of it styles to unregister.
+			 *
+			 * @var array<string, string[]>
+			 *
+			 * @see https://github.com/moderntribe/square-one/blob/main/docs/basics/blocks.md#configuring-block-options
+			 */
+			self::DENY_BLOCK_STYLES      => [
+				'core/image'     => [ 'rounded', 'default' ],
+				'core/quote'     => [ 'plain', 'large', 'default' ],
+				'core/separator' => [ 'default', 'wide', 'line', 'dots' ],
+			],
+
+			/**
 			 * An array of block type style overrides
 			 *
 			 * Each item in the array should be a factory that returns a Block_Style_Override
 			 *
 			 * TODO: Create a proper thumbnail of the style for the block editor: http://p.tri.be/dmsAwK
 			 */
-			self::STYLES           => DI\add( [
+			self::STYLES                 => DI\add( [
 				DI\factory( static function () {
 					return new Block_Style_Override( [ 'core/paragraph' ], [
 						[
@@ -113,7 +127,8 @@ class Blocks_Definer implements Definer_Interface {
 				} ),
 			] ),
 
-			Block_Deny_List::class => DI\autowire()->constructor( DI\get( self::DENY_LIST ) ),
+			Block_Deny_List::class       => DI\autowire()->constructor( DI\get( self::DENY_LIST ) ),
+			Block_Style_Deny_List::class => DI\autowire()->constructor( DI\get( self::DENY_BLOCK_STYLES ) ),
 		];
 	}
 

--- a/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php
@@ -26,6 +26,13 @@ class Blocks_Subscriber extends Abstract_Subscriber {
 			return $this->container->get( Block_Deny_List::class )->filter_block_denylist( $types );
 		}, 10, 1 );
 
+		/**
+		 * Adds the deny list of block styles to the JS_Config class.
+		 */
+		add_filter( 'tribe/project/blocks/style_denylist', function ( array $types ): array {
+			return $this->container->get( Block_Style_Deny_List::class )->filter_block_style_denylist( $types );
+		}, 10, 1 );
+
 		add_action( 'after_setup_theme', function (): void {
 			$this->container->get( Theme_Support::class )->register_theme_supports();
 

--- a/wp-content/themes/core/assets/js/src/admin/config/wp-settings.js
+++ b/wp-content/themes/core/assets/js/src/admin/config/wp-settings.js
@@ -2,3 +2,4 @@ const wp = window.modern_tribe_admin_config || {};
 
 export const HMR_DEV = wp.hmr_dev || 0;
 export const BLOCK_DENYLIST = wp.block_denylist || [];
+export const BLOCK_STYLE_DENYLIST = wp.block_style_denylist || [];

--- a/wp-content/themes/core/assets/js/src/admin/core/block-styles.js
+++ b/wp-content/themes/core/assets/js/src/admin/core/block-styles.js
@@ -1,14 +1,25 @@
+import { BLOCK_STYLE_DENYLIST } from '../config/wp-settings';
+import { unregisterBlockStyle } from '@wordpress/blocks';
+
 /**
  * @function unregisterStyles
- * @description Unregisters core block styles added client-side. Styles added
- * 				server-side using register_block_style should be unregistered
- * 				using the server-side unregister_block_styles function.
+ * @description Unregisters core block styles.
  */
 
-/* global wp */
-
 const unregisterStyles = () => {
-	wp.blocks.unregisterBlockStyle( 'core/image', [ 'rounded', 'default' ] );
+	const blockStyles = [];
+
+	for ( const [ block, styles ] of Object.entries( BLOCK_STYLE_DENYLIST ) ) {
+		unregisterBlockStyle( block, styles );
+		blockStyles.push( `${ block }:${ styles.toString() }` );
+	}
+
+	if ( ! blockStyles.length ) {
+		console.info( 'SquareOne Admin: No block styles to unregister from Gutenberg.' );
+		return;
+	}
+
+	console.info( 'SquareOne Admin: Unregistered these styles from Gutenberg: ', blockStyles );
 };
 
 export default unregisterStyles;


### PR DESCRIPTION
## What does this do/fix?

- Removes PHP based functionality for unregistering block styles
- Adds functionality for specifying blocks and their styles for unregistering
- Provides WP filter for it
- Unregisters specified blocks styles from JS

To remove specific core block styles from editor add the records to the `\Tribe\Project\Blocks\Blocks_Definer::DENY_BLOCK_STYLES` like this:
```php
self::DENY_BLOCK_STYLES => [
    'core/separator' => [ 'default', 'wide', 'line', 'dots' ],
]
```

## QA

N/A

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because...
- [x] No, I need help figuring out how to write the tests.

