### PR TITLE
[SQONE-691]: Buttons Block Updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2022.07
+* Fixed: Misnamed Buttons Block classes and attached button styles
+
 ## 2022.06
 * Fixed: Erroneous link clicks in card.js for mouse right-clicks on Windows. 
 * Bumped: Tribe Libs to 3.4.18 to update block generators to escape labels.

--- a/wp-content/themes/core/components/blocks/buttons/buttons.php
+++ b/wp-content/themes/core/components/blocks/buttons/buttons.php
@@ -28,7 +28,7 @@ if ( empty( $c->get_buttons()->count() ) ) {
 			Link_Controller::ADD_ARIA_LABEL => $button->cta->add_aria_label,
 			Link_Controller::ARIA_LABEL     => $button->cta->aria_label,
 			Link_Controller::CLASSES        => array_filter( [
-				'b-links__list-link',
+				'b-buttons__button',
 				$style,
 			] ),
 		] );

--- a/wp-content/themes/core/components/blocks/buttons/css/buttons.pcss
+++ b/wp-content/themes/core/components/blocks/buttons/css/buttons.pcss
@@ -20,4 +20,16 @@
 	&:last-child {
 		margin-right: 0;
 	}
+
+	&.b-style__primary {
+		@mixin a-btn-primary;
+	}
+
+	&.b-style__secondary {
+		@mixin a-btn-secondary;
+	}
+
+	&.b-style__cta {
+		@mixin a-cta-primary;
+	}
 }


### PR DESCRIPTION
## What does this do/fix?
This PR fixes up some a couple of issues causing the Buttons block to not get styled correctly:

1. Fixes individual button class name from being `b-links__list-link` to `b-buttons__button`.
2. Attaches appropriate action mixin to each button style type.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/SQONE-691)

Links to deployed, scaffolded demo:
- [Link to Demo](https://sq1-pr1015.moderntribe.qa/buttons-block-demo/)

Screenshots/video:
- [Buttons Block Before](http://p.tri.be/nbSX6i)
- [Buttons Block After](http://p.tri.be/5Ckpyy)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

