### PR TITLE
Don't trigger click for mouse right-clicks on Windows.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.06
+* Fixed: Erroneous link clicks in card.js for mouse right-clicks on Windows. 
 * Bumped: Tribe Libs to 3.4.18 to update block generators to escape labels.
 * Added: PHP side functionality and filter for unregistering block styles.
 * Fixed: Replaces `__()` with `esc_html__()` in `wp-content/plugins/core/src/Blocks` folder

--- a/wp-content/themes/core/components/card/js/card.js
+++ b/wp-content/themes/core/components/card/js/card.js
@@ -49,7 +49,7 @@ const handleCardClick = ( e ) => {
  * @param e
  */
 const handleCardMouseDown = ( e ) => {
-	if ( EXCLUDED_TARGETS.includes( e.target.nodeName ) ) {
+	if ( EXCLUDED_TARGETS.includes( e.target.nodeName ) || e.button !== 0 ) {
 		return;
 	}
 
@@ -65,7 +65,7 @@ const handleCardMouseDown = ( e ) => {
  * @param e
  */
 const handleCardMouseUp = ( e ) => {
-	if ( EXCLUDED_TARGETS.includes( e.target.nodeName ) ) {
+	if ( EXCLUDED_TARGETS.includes( e.target.nodeName ) || e.button !== 0 ) {
 		return;
 	}
 


### PR DESCRIPTION
## What does this do/fix?
Fixes an issue on Windows where right-clicks were incorrectly triggering link click-through.

This has been tested on an active project already. [Related Slack convo](https://tribe.slack.com/archives/C01CY7418GY/p1657046449714999)