### PR TITLE
Bugfix: embeds in reusable blocks not displaying on the frontend

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.07
+* Fixed: Embeds in reusable blocks not displaying on the frontend. https://core.trac.wordpress.org/ticket/46457
 * Added: Core Columns block with support for headings, paragraphs, lists, and images.
 * Updated: Base kitchen sink styles for improves specificity and admin support.
 * Fixed: Misnamed Buttons Block classes and attached button styles

--- a/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
+++ b/wp-content/plugins/core/src/Theme/Theme_Subscriber.php
@@ -90,6 +90,15 @@ class Theme_Subscriber extends Abstract_Subscriber {
 	}
 
 	private function oembed(): void {
+		// Fix reusable blocks from not rendering embeds on the frontend by re-running autoembed at a higher priority than do_blocks()
+		add_filter( 'the_content', static function ( $content ) {
+			if ( is_admin() ) {
+				return $content;
+			}
+
+			return $GLOBALS['wp_embed']->autoembed( $content );
+		}, 10, 1 );
+
 		add_filter( 'oembed_dataparse', function ( $html, $data, $url ) {
 			return $this->container->get( Oembed_Filter::class )->get_video_component( (string) $html, (object) $data, (string) $url );
 		}, 999, 3 );


### PR DESCRIPTION
## What does this do/fix?

- [BUGFIX]: Long standing Gutenberg/Core WP bug that just displays the hyperlink text instead of the actual embed on the frontend.


## QA

The editor shows the embed fine:
![image](https://user-images.githubusercontent.com/1066195/179780943-ab219d61-90d3-44c4-acae-033b53584cb8.png)

However, the frontend just shows the hyperlink text:
![image](https://user-images.githubusercontent.com/1066195/179781016-9dcaefff-48fc-4a3b-8a71-21c185f6609e.png)

After the fix:
![image](https://user-images.githubusercontent.com/1066195/179781193-19df3882-871f-46d8-84d7-f5cf4725639b.png)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a Gutenberg/core work around.
- [ ] No, I need help figuring out how to write the tests.

