### PR TITLE
[SQONE-708]: Fix for TinyMCE floating toolbar repositioning infinite loop.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.07
+* Fixed: TinyMCE floating toolbar repositioning loop.
 * Added: Block Category (Custom) for all custom blocks.
 * Updated: Block fields layout and language for consistency.
 * Updated: Removed `image_select` fields in favor of `button_group` fields on blocks.

--- a/wp-content/plugins/core/src/Admin/Admin_Subscriber.php
+++ b/wp-content/plugins/core/src/Admin/Admin_Subscriber.php
@@ -4,6 +4,7 @@ namespace Tribe\Project\Admin;
 
 use Tribe\Libs\Container\Abstract_Subscriber;
 use Tribe\Project\Admin\Editor\Classic_Editor_Formats;
+use Tribe\Project\Admin\Editor\Editor_Script_Loader;
 use Tribe\Project\Admin\Editor\Editor_Styles;
 
 class Admin_Subscriber extends Abstract_Subscriber {
@@ -19,6 +20,7 @@ class Admin_Subscriber extends Abstract_Subscriber {
 	private function editor(): void {
 		$this->editor_styles();
 		$this->editor_formats();
+		$this->editor_scripts();
 	}
 
 	private function editor_styles(): void {
@@ -48,6 +50,12 @@ class Admin_Subscriber extends Abstract_Subscriber {
 		}, 10, 1 );
 		add_filter( 'acf/fields/wysiwyg/toolbars', function ( $toolbars ) {
 			return $this->container->get( Classic_Editor_Formats::class )->add_minimal_toolbar( (array) $toolbars );
+		}, 10, 1 );
+	}
+
+	private function editor_scripts(): void {
+		add_filter( 'mce_external_plugins', function ( $plugins ) {
+			return $this->container->get( Editor_Script_Loader::class )->add_mce_plugins( $plugins );
 		}, 10, 1 );
 	}
 

--- a/wp-content/plugins/core/src/Admin/Editor/Editor_Script_Loader.php
+++ b/wp-content/plugins/core/src/Admin/Editor/Editor_Script_Loader.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Admin\Editor;
+
+class Editor_Script_Loader {
+
+	public const TRIBE_TINYMCE_PLUGIN = 'tribe-tinymce';
+
+	/**
+	 * Add custom TinyMCE plugins
+	 *
+	 * @filter mce_external_plugins
+	 *
+	 * @param array $plugins
+	 *
+	 * @return array $plugins
+	 */
+	public function add_mce_plugins( array $plugins ): array {
+		$plugins[ self::TRIBE_TINYMCE_PLUGIN ] = trailingslashit( get_template_directory_uri() ) . 'assets/js/src/admin/editor/tribe-tinymce.js';
+
+		return $plugins;
+	}
+
+}

--- a/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
@@ -4,9 +4,9 @@
  * This is especially likely to happen when the TinyMCE editor is inside of a
  * repeater (as in the Accordion block, for example) due the restricted
  * horizontal space.
- * 
+ *
  * The issue is ticketed here: https://core.trac.wordpress.org/ticket/44911.
- * 
+ *
  * The issue is caused by some poor positioning logic in
  * `wp-includes/js/tinymce/plugins/wordpress/plugin.js`, which sometimes places
  * the floating toolbar slightly off-screen when positioning it next to the
@@ -16,10 +16,10 @@
  * element being edited once the scrolling finishes. Hiding the toolbar causes
  * the scrollbars to disappear and the plugin then shows the toolbar again,
  * triggering the scrollbars, triggering the hiding of the toolbar, etc, etc.
- * 
+ *
  * The fix should be rather simple, but difficult to apply. It would essentially
  * be a one-liner in the core TinyMCE Wordpress plugin, were that a normal
- * library you could patch or replace. Instead, we use this custom plugin to 
+ * library you could patch or replace. Instead, we use this custom plugin to
  * observe the toolbar and fix the positioning in the trouble cases. TinyMCE
  * plugins are meant to be independent and "closed", so there's no way to fix
  * the errant positioning function directly. Instead we quickly recalculate and

--- a/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
@@ -1,3 +1,30 @@
+/**
+ * This custom TinyMCE plugin fixes an issue where the TinyMCE floating/inline
+ * toolbar (usually when editing a link in the WYSIWYG) "flickers" endlessly.
+ * This is especially likely to happen when the TinyMCE editor is inside of a
+ * repeater (as in the Accordion block, for example) due the restricted
+ * horizontal space.
+ * 
+ * The issue is ticketed here: https://core.trac.wordpress.org/ticket/44911.
+ * 
+ * The issue is caused by some poor positioning logic in
+ * `wp-includes/js/tinymce/plugins/wordpress/plugin.js`, which sometimes places
+ * the floating toolbar slightly off-screen when positioning it next to the
+ * inline element being edited. Overflowing the body this way causes horizontal
+ * scrollbars to appear and triggers a `scrollwindow` event. The same plugin
+ * hides the toolbar during scroll events to be repositioned over the inline
+ * element being edited once the scrolling finishes. Hiding the toolbar causes
+ * the scrollbars to disappear and the plugin then shows the toolbar again,
+ * triggering the scrollbars, triggering the hiding of the toolbar, etc, etc.
+ * 
+ * The fix should be rather simple, but difficult to apply. It would essentially
+ * be a one-liner in the core TinyMCE Wordpress plugin, were that a normal
+ * library you could patch or replace. Instead, we use this custom plugin to 
+ * observe the toolbar and fix the positioning in the trouble cases. TinyMCE
+ * plugins are meant to be independent and "closed", so there's no way to fix
+ * the errant positioning function directly. Instead we quickly recalculate and
+ * reposition the element ourselves after the bad positioning has been done.
+ */
 ( function() {
 	window.tinymce.PluginManager.add( 'tribe-tinymce', function( editor ) {
 		let mceIframe;

--- a/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
@@ -1,0 +1,64 @@
+( function() {
+	window.tinymce.PluginManager.add( 'tribe-tinymce', function( editor ) {
+		let mceIframe;
+		let currentSelection;
+
+		editor.on( 'nodechange', function( event ) {
+			currentSelection = event.element;
+		} );
+
+		editor.on( 'init', function() {
+			mceIframe = document.getElementById( editor.id + '_ifr' );
+
+			window.tinymce.$( '.mce-inline-toolbar-grp:not(.tribe-tinymce-processed)' ).each( ( index, toolbar ) => {
+				toolbar.classList.add( 'tribe-tinymce-processed' );
+
+				const observer = new MutationObserver( function( ) {
+					// Only respond when there is a current selection and the toolbar has
+					// the specific class condition we need to fix.
+					if ( ! currentSelection || ! toolbar.classList.contains( 'mce-arrow-left' ) ) {
+						return;
+					}
+
+					// We are essentially overriding the reposition() function in
+					// wp-includes/js/tinymce/plugins/wordpress/plugin.js to prevent
+					// inline toolbars from floating off the right side of the screen and
+					// getting stuck in an infinite show/hide loop.
+					const scrollX = window.pageXOffset || document.documentElement.scrollLeft,
+						windowWidth = window.innerWidth,
+						windowHeight = window.innerHeight,
+						iframeRect = mceIframe ? mceIframe.getBoundingClientRect() : {
+							top: 0,
+							right: windowWidth,
+							bottom: windowHeight,
+							left: 0,
+							width: windowWidth,
+							height: windowHeight,
+						},
+						selection = currentSelection.getBoundingClientRect(),
+						left = selection.left + iframeRect.left + scrollX;
+
+					// This is the logic missing from the core plugin. If the right side
+					// of the toolbar hangs off the right side of the screen, it will
+					// cause an infinite loop of scroll events causing repositions causing
+					// scroll events.
+					if ( left + toolbar.offsetWidth >= iframeRect.left + iframeRect.width + scrollX ) {
+						toolbar.classList.remove( 'mce-arrow-left' );
+						toolbar.classList.add( 'mce-arrow-right' );
+						toolbar.style.left = iframeRect.left + scrollX + selection.right - toolbar.offsetWidth + 'px';
+
+						// The toolbar width may change when we change classes, so we look
+						// it up again here after the browser has applied our new class.
+						// Otherwise, our positioning will be off by the difference between
+						// the toolbar width before and after the change.
+						requestAnimationFrame( () => {
+							toolbar.style.left = iframeRect.left + scrollX + selection.right - toolbar.offsetWidth + 'px';
+						} );
+					}
+				} );
+
+				observer.observe( toolbar, { attributes: true } );
+			} );
+		} );
+	} );
+} )();


### PR DESCRIPTION
## What does this do/fix?

Fixes an issue where the TinyMCE floating/inline toolbar (usually when editing a link in the WYSIWYG) "flickers" endlessly. This is especially likely to happen when the TinyMCE editor is inside of a repeater (as in the Accordion block, for example) due the restricted horizontal space.

The issue is ticketed here: https://core.trac.wordpress.org/ticket/44911 and everyone pretty much agrees that it exists, but no one has fixed it in ~3 years.

The issue is caused by some poor positioning logic in `wp-includes/js/tinymce/plugins/wordpress/plugin.js`, which sometimes places the floating toolbar slightly off-screen when positioning it next to the inline element being edited. Overflowing the body this way causes horizontal scrollbars to appear and triggers a `scrollwindow` event. The same plugin hides the toolbar during scroll events to be repositioned over the inline element being edited once the scrolling finishes. Hiding the toolbar causes the scrollbars to disappear and the plugin then shows the toolbar again, triggering the scrollbars, triggering the hiding of the toolbar, etc, etc.

The fix is rather simple, but difficult to apply. It would essentially be a one-liner in the core TinyMCE Wordpress plugin, were that a normal library you could patch or replace. 😢 Instead, I've created a custom TinyMCE plugin to observe the toolbar and fix the positioning in the trouble cases. TinyMCE plugins are meant to be independent and "closed", so there's no way to fix the errant positioning function directly. Instead we quickly recalculate and reposition the element ourselves after the bad positioning has been done.


## QA

The ticket for this PR: https://github.com/moderntribe/turner-industries/pull/78
Original fix forMilitary Affairs: https://github.com/Microsoft-Stories/military-affairs/pull/221
Subsequent fix for Turner Industries: https://github.com/moderntribe/turner-industries/pull/78

Screenshots/video:
![image](https://user-images.githubusercontent.com/6012180/181623854-d6adde59-c2be-42d1-ac4e-fba2eea9fef1.png)

Important note:
This can potentially affect any inline WYSIWYG toolbar, so the potential effects of some bad code here are substantial. Also, there's already some existing "weirdness" with the TinyMCE editor toolbar positioning in some scenarios that isn't related to this fix—this fix should just make the toolbar (at-least) usable in all cases.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because I don't know how you'd test it. Maybe it does?
- [ ] No, I need help figuring out how to write the tests.

