### PR TITLE
Bugfix: Jira ticket prefixing numbered projects

### DIFF
--- a/.lefthook/prepare-commit-msg/prefix-with-jira-ticket.php
+++ b/.lefthook/prepare-commit-msg/prefix-with-jira-ticket.php
@@ -25,7 +25,7 @@ function is_valid_commit_source( string $source ): bool {
 }
 
 function parse_ticket( string $branch ): string {
-	if ( preg_match( '/[A-Z]{2,}-\d+/i', $branch, $matches ) ) {
+	if ( preg_match( '/[A-Z0-9]{2,}-\d+/i', $branch, $matches ) ) {
 		return $matches[0];
 	}
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2022.08
+* Fixed: Branches that have Jira projects in them that contained numbers in the name would not properly prefix git commits, e.g. `feature/DATA22-3/some-new-feature`
+
+
 ## 2022.07
 * Fixed: TinyMCE floating toolbar repositioning loop. https://core.trac.wordpress.org/ticket/44911
 * Fixed: Set Static Analysis format for GitHub in Actions.


### PR DESCRIPTION
## What does this do/fix?

* Fixed: Branches that have Jira projects in them that contained numbers in the name would not properly prefix git commits, e.g. `feature/DATA22-3/some-new-feature`


## QA

- Branches that contain a project with numbers will now prefix commit messages, e.g. if you commit `Updated card styles`, it would properly become `[DATA22-3]: Updated card styles`.
- Original style project names still work properly, e.g. `SQONE-689`.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a dev tool to modify git commit messages.
- [ ] No, I need help figuring out how to write the tests.

