### PR TITLE
Bugfix: PHPStan have_posts() false positive

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2202.08
+* Fixed: False positive on `have_posts()` using PHPStan if proceeded by an `if ( have_posts() ):`, utilizing a new [wordpress-overrides.stub file](dev/stubs/wordpress-overrides.stub)  
+
 ## 2022.07
 * Fixed: TinyMCE floating toolbar repositioning loop. https://core.trac.wordpress.org/ticket/44911
 * Fixed: Set Static Analysis format for GitHub in Actions.

--- a/dev/stubs/wordpress-overrides.stub
+++ b/dev/stubs/wordpress-overrides.stub
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Various overrides to fix WP core false positives.
+ *
+ * @since 2.2.0
+ */
+
+
+/**
+* Whether current WordPress query has results to loop over.
+*
+* @since 1.5.0
+*
+* @global WP_Query $wp_query Global WP_Query instance.
+*
+* @return bool
+* @phpstan-impure
+*/
+function have_posts() {
+}
+
+class WP_Query {
+/**
+* Determines whether there are more posts available in the loop.
+*
+* Calls the {@see 'loop_end'} action when the loop is complete.
+*
+* @since 1.5.0
+*
+* @return bool True if posts are available, false if end of loop.
+* @phpstan-impure
+*/
+public function have_posts() {
+}
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,8 @@ parameters:
 	bootstrapFiles:
 		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
 		- vendor/php-stubs/acf-pro-stubs/acf-pro-stubs.php
+	stubFiles:
+		- dev/stubs/wordpress-overrides.stub
 	tmpDir: .phpstan-cache/
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:


### PR DESCRIPTION
## What does this do/fix?

- Properly tells PHPStan that the `have_posts()` function is impure


## QA

The following will no longer be tagged as `While loop condition is always true.` or `Unreachable statement - code above always terminates.`:

```php
			<?php
			if ( have_posts() ) : ?>
				<div class="archive-loop__items g-3-up">
					<?php while ( have_posts() ) :
						the_post();
						get_template_part( 'components/card/card', '', $c->get_extended_card_args(
							$c->get_meta_primary(),
							$c->get_meta_secondary()
						) );
					endwhile; ?>
				</div>
				<?php get_template_part( 'components/pagination/loop/loop' );
			else :
				get_template_part( 'components/no_results/no_results' );
			endif;
			?>
```

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a change to code analysis configuration.
- [ ] No, I need help figuring out how to write the tests.

