### PR TITLE
Bugfix/post loop middleware unique field names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2202.08
+* Fixed: Post Loop Block Middleware config being shared across blocks due to non-unique ACF key names.
 * Fixed: Updated Linkedin share link URL.
 * Updated: Added separate file with registerBlockType filter which runs before ready event.
 * Content Loop Block refactoring

--- a/dev/tests/tests/integration/Tribe/Project/Blocks/Middleware/Post_Loop/Field_Middleware/PostLoopFieldMiddlewareTest.php
+++ b/dev/tests/tests/integration/Tribe/Project/Blocks/Middleware/Post_Loop/Field_Middleware/PostLoopFieldMiddlewareTest.php
@@ -91,7 +91,7 @@ final class PostLoopFieldMiddlewareTest extends Test_Case {
 		// Cards
 		$card_list = $attributes['fields'][1];
 		$this->assertSame( $block::CARD_LIST, $card_list['name'] );
-		$this->assertSame( sprintf( 'field_%s', $block::CARD_LIST ), $card_list['key'] );
+		$this->assertSame( sprintf( 'field_%s_%s', $block::NAME, $block::CARD_LIST ), $card_list['key'] );
 		$this->assertCount( 4, $card_list['sub_fields'] );
 
 		// Test manual post subfields were added to ensure the next test is doing proper assertions.
@@ -105,7 +105,7 @@ final class PostLoopFieldMiddlewareTest extends Test_Case {
 		// Featured cards
 		$featured_cards = $attributes['fields'][3];
 		$this->assertSame( $block::FEATURED_CARD_LIST, $featured_cards['name'] );
-		$this->assertSame( sprintf( 'field_%s', $block::FEATURED_CARD_LIST ), $featured_cards['key'] );
+		$this->assertSame( sprintf( 'field_%s_%s', $block::NAME, $block::FEATURED_CARD_LIST ), $featured_cards['key'] );
 		$this->assertCount( 4, $card_list['sub_fields'] );
 
 	}
@@ -175,7 +175,7 @@ final class PostLoopFieldMiddlewareTest extends Test_Case {
 
 		$this->assertSame( 'group_test_block', $attributes['key'] );
 		$this->assertSame( $block::CARD_LIST, $attributes['fields'][1]['name'] );
-		$this->assertSame( sprintf( 'field_%s', $block::CARD_LIST ), $attributes['fields'][1]['key'] );
+		$this->assertSame( sprintf( 'field_%s_%s', $block::NAME, $block::CARD_LIST ), $attributes['fields'][1]['key'] );
 
 		$manual_repeater_sub_fields = $attributes['fields'][1]['sub_fields'][3]['sub_fields'];
 

--- a/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
+++ b/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
@@ -28,6 +28,12 @@ class Post_Loop_Field_Config extends Field_Model {
 	];
 
 	/**
+	 * Automatically populated with the $block::NAME constant value when
+	 * the middleware is processed to build ACF keys.
+	 */
+	public string $block_name = '';
+
+	/**
 	 * The ACF group/field/section where the Post Loop Fields will appear
 	 * under.
 	 */

--- a/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
+++ b/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
@@ -42,8 +42,6 @@ class Post_Loop_Field_Config extends Field_Model {
 	/**
 	 * The name of the field, generally a constant you created in a
 	 * Block_Config.
-	 *
-	 * @note This name must be unique to the block.
 	 */
 	public string $field_name = '';
 

--- a/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Field_Middleware/Post_Loop_Field_Middleware.php
+++ b/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Field_Middleware/Post_Loop_Field_Middleware.php
@@ -92,7 +92,8 @@ class Post_Loop_Field_Middleware extends Abstract_Field_Middleware implements Ct
 				continue;
 			}
 
-			$this->config = $post_loop_config;
+			$this->config             = $post_loop_config;
+			$this->config->block_name = $block::NAME;
 
 			// Find the field/group/section where our post loop fields will be added to.
 			$section = $this->find_field( $fields, $this->config->group );
@@ -108,7 +109,7 @@ class Post_Loop_Field_Middleware extends Abstract_Field_Middleware implements Ct
 	}
 
 	protected function get_post_loop_group(): Field_Group {
-		$group = new Field_Group( $this->config->field_name, [
+		$group = new Field_Group( $this->config->block_name . '_' . $this->config->field_name, [
 			'name' => $this->config->field_name,
 		] );
 
@@ -483,7 +484,7 @@ class Post_Loop_Field_Middleware extends Abstract_Field_Middleware implements Ct
 	 * @return string The formatted field key.
 	 */
 	protected function build_field_key( string $name ): string {
-		return sprintf( '%s_%s', $this->config->field_name, $name );
+		return sprintf( '%s_%s_%s', $this->config->block_name, $this->config->field_name, $name );
 	}
 
 }

--- a/wp-content/themes/core/components/blocks/content_loop/Content_Loop_Controller.php
+++ b/wp-content/themes/core/components/blocks/content_loop/Content_Loop_Controller.php
@@ -116,7 +116,7 @@ class Content_Loop_Controller extends Abstract_Controller {
 			$cards[] = [
 				Card_Controller::STYLE           => $layout,
 				Card_Controller::USE_TARGET_LINK => (bool) $post->cta->link->url,
-				Card_Controller::META_PRIMARY    => $this->get_card_meta_primary( $cat->name ),
+				Card_Controller::META_PRIMARY    => $this->get_card_meta_primary( $cat->name ?? '' ),
 				Card_Controller::TITLE           => $this->get_card_title( $post->post_title, $uuid ),
 				Card_Controller::META_SECONDARY  => $this->get_card_meta_secondary( (string) get_the_date( 'F Y', $post->post() ) ),
 				Card_Controller::DESCRIPTION     => $show ? $this->get_card_description( $post->post_excerpt ) : null,
@@ -245,7 +245,11 @@ class Content_Loop_Controller extends Abstract_Controller {
 		] );
 	}
 
-	private function get_card_meta_primary( string $cat_name ): Deferred_Component {
+	private function get_card_meta_primary( string $cat_name ): ?Deferred_Component {
+		if ( ! $cat_name ) {
+			return null;
+		}
+
 		return defer_template_part(
 			'components/container/container',
 			'',


### PR DESCRIPTION
## What does this do/fix?

- ACF's field store will store a field by key, so each key needs to be unique, even if under a group. When putting two blocks with Post Loop Field Middleware on the same page, the configuration was being overwritten/shared due to non-unique key names.
- Post Loop Middleware keys are now prefixed with the block name.
- Fixed a bug in the Content Loop Block where there was no check if the post has a category, because one can select pages and they don't have categories.


## QA

- Post Loop configuration should now be properly isolated to each block

## Tests

Does this have tests?

- [x] Yes
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

