### PR TITLE
Chore: Update lefthook ticket prefixing

### DIFF
--- a/.lefthook/prepare-commit-msg/prefix-with-jira-ticket.php
+++ b/.lefthook/prepare-commit-msg/prefix-with-jira-ticket.php
@@ -25,8 +25,8 @@ function is_valid_commit_source( string $source ): bool {
 }
 
 function parse_ticket( string $branch ): string {
-	if ( preg_match( '/[A-Z0-9]{2,}-\d+/i', $branch, $matches ) ) {
-		return $matches[0];
+	if ( preg_match( '/[A-Z0-9]{2,}-\d+\//i', $branch, $matches ) ) {
+		return rtrim( $matches[0], '/' );
 	}
 
 	return '';
@@ -38,6 +38,7 @@ function is_protected_branch( string $branch ): bool {
 		'master',
 		'develop',
 		'sprint/',
+		'server/',
 	];
 
 	foreach ( $protected_branches as $protected_branch ) {
@@ -47,6 +48,11 @@ function is_protected_branch( string $branch ): bool {
 	}
 
 	return false;
+}
+
+// Don't run during automated tests.
+if ( ! empty( $_ENV['TEST_DB_USER'] ) ) {
+	return;
 }
 
 /**

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## 2202.08
+* Updated: Lefthook package renamed from @arkweid/lefthook to @evilmartians/lefthook. Updated to v1.1.1.
+* Updated: `prefix-with-jira-ticket.php` lefthook script for better ticket matching and added tests.
 * Fixed: Post Loop Block Middleware config being shared across blocks due to non-unique ACF key names.
 * Fixed: Updated Linkedin share link URL.
 * Updated: Added separate file with registerBlockType filter which runs before ready event.

--- a/dev/tests/tests/unit/PrefixJiraTicketTest.php
+++ b/dev/tests/tests/unit/PrefixJiraTicketTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+use Tribe\Tests\Unit;
+
+/**
+ * Test lefthook git hook ticket prefixing.
+ */
+final class PrefixJiraTicketTest extends Unit {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		require_once dirname( __DIR__, 4 ) . '/.lefthook/prepare-commit-msg/prefix-with-jira-ticket.php';
+	}
+
+	public function test_it_finds_tickets_in_branches():void {
+		$ticket = parse_ticket( 'feature/SQONE-698/my-feature' );
+		$this->assertSame( 'SQONE-698', $ticket );
+
+		$ticket = parse_ticket( 'feature/MIIID23-36/my-feature' );
+		$this->assertSame( 'MIIID23-36', $ticket );
+
+		$ticket = parse_ticket( 'test/MSL233-15/my-feature' );
+		$this->assertSame( 'MSL233-15', $ticket );
+
+		$ticket = parse_ticket( 'test/EEY88-776/my-feature' );
+		$this->assertSame( 'EEY88-776', $ticket );
+
+		$ticket = parse_ticket( 'test/YEAH-44/my-feature' );
+		$this->assertSame( 'YEAH-44', $ticket );
+	}
+
+	public function test_it_does_not_find_a_ticket_in_invalid_branches(): void {
+		$ticket = parse_ticket( 'feature/with-a-number-but-no-ticket-22' );
+		$this->assertEmpty( $ticket );
+
+		$ticket = parse_ticket( 'feature/test/with-a-number-but-no-ticket-23' );
+		$this->assertEmpty( $ticket );
+
+		$ticket = parse_ticket( 'security/update-wp-to-6.0.2' );
+		$this->assertEmpty( $ticket );
+
+		$ticket = parse_ticket( 'feature/22-test/my-feature' );
+		$this->assertEmpty( $ticket );
+
+		$ticket = parse_ticket( 'SQONE-698' );
+		$this->assertEmpty( $ticket );
+	}
+
+	public function test_it_finds_protected_branches(): void {
+		$this->assertTrue( is_protected_branch( 'main' ) );
+		$this->assertTrue( is_protected_branch( 'master' ) );
+		$this->assertTrue( is_protected_branch( 'develop' ) );
+		$this->assertTrue( is_protected_branch( 'sprint/22.08' ) );
+		$this->assertTrue( is_protected_branch( 'sprint/cookie' ) );
+		$this->assertTrue( is_protected_branch( 'server/development' ) );
+		$this->assertTrue( is_protected_branch( 'server/staging' ) );
+		$this->assertTrue( is_protected_branch( 'server/production' ) );
+	}
+
+	public function test_it_allows_unprotected_branches(): void {
+		$this->assertFalse( is_protected_branch( 'chore/SQONE-698/test-branch') );
+		$this->assertFalse( is_protected_branch( 'random-name') );
+		$this->assertFalse( is_protected_branch( 'servers/test') );
+	}
+
+}

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "@arkweid/lefthook": "0.7.5",
     "@babel/cli": "^7.7.0",
     "@babel/core": "^7.14.3",
     "@babel/plugin-proposal-class-properties": "^7.7.0",
@@ -120,6 +119,7 @@
     "@babel/plugin-transform-runtime": "^7.16.0",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
+    "@evilmartians/lefthook": "^1.1.1",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,7 @@ parameters:
 	bootstrapFiles:
 		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
 		- vendor/php-stubs/acf-pro-stubs/acf-pro-stubs.php
+		- .lefthook/prepare-commit-msg/prefix-with-jira-ticket.php
 	stubFiles:
 		- dev/stubs/wordpress-overrides.stub
 	tmpDir: .phpstan-cache/

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@arkweid/lefthook@0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@arkweid/lefthook/-/lefthook-0.7.5.tgz#e7572c2d182158fac26eecb74eebb1af822cb084"
-  integrity sha512-+fLkcRWhVbgm4yWit6aiodjEGK6yRhwDnRZeIqOpiSbnppNRznDEYGYDBGKf7cxqj5LhUkn60nc1UzZ5JSdF1A==
-
 "@babel/cli@^7.7.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.16.0.tgz#a729b7a48eb80b49f48a339529fc4129fd7bcef3"
@@ -1176,6 +1171,11 @@
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+
+"@evilmartians/lefthook@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@evilmartians/lefthook/-/lefthook-1.1.1.tgz#26e0de9ca3df1c8d2d97840f187a52cd95bb5f59"
+  integrity sha512-5C/AD937A6jz4mdBLAKXIeYVkxvLmPWxlv1YWfuHcIwZ2wp4W3z1Htjjtp+7gtO41CoCycIJcaxLfwaAsbS6qA==
 
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"


### PR DESCRIPTION
## What does this do/fix?

* Updated: Lefthook package renamed from @arkweid/lefthook to @evilmartians/lefthook. Updated to v1.1.1.
* Updated: `prefix-with-jira-ticket.php` lefthook script for better ticket matching and added tests.

## QA

After a `lefthook install -a`, commits to a branch with a ticket in it, e.g. `feature/JIRA-123/cool-thing` will continue to prefix the commit with the ticket, e.g. `[JIRA-123]: my commit message`.

## Tests

Does this have tests?

- [x] Yes
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.



[JIRA-123]: https://moderntribe.atlassian.net/browse/JIRA-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ