### PR TITLE
Git ignore lefthook-local.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ phpcs.xml
 .phpcs-cache
 phpstan.neon
 .phpstan-cache
+/lefthook-local.yml
 
 
 # Added by so cli

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2202.08
+## 2022.09
+* Added: Git ignore [lefthook-local.yml](https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md#local-config) so developers can customize the version of PHP calling the script if required. 
+
+## 2022.08
 * Updated: Lefthook package renamed from @arkweid/lefthook to @evilmartians/lefthook. Updated to v1.1.1.
 * Updated: `prefix-with-jira-ticket.php` lefthook script for better ticket matching and added tests.
 * Fixed: Post Loop Block Middleware config being shared across blocks due to non-unique ACF key names.


### PR DESCRIPTION
## What does this do/fix?

- Git ignore [lefthook-local.yml](https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md#local-config) as this version of SquareOne's PHPCS requires PHP 8.0+ locally, and will throw errors if that's not your default version. This allows developers to override the lefthook processing and point to a different PHP location if they need to.


## QA

- copy `lefthook.yml` to `lefthook-local.yml` and customize it.
- Lefthook will use the local version and it should be git ignored so it doesn't get committed.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a 3rd party feature.
- [ ] No, I need help figuring out how to write the tests.

