### PR TITLE
[SQONE-609]: Fix regression in Tabs Controller

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2202.08
+## 2022.09
+* Fixed: Regression from removing default typing of tab panel classes property
+
+## 2022.08
 * Updated: Lefthook package renamed from @arkweid/lefthook to @evilmartians/lefthook. Updated to v1.1.1.
 * Updated: `prefix-with-jira-ticket.php` lefthook script for better ticket matching and added tests.
 * Fixed: Post Loop Block Middleware config being shared across blocks due to non-unique ACF key names.

--- a/wp-content/themes/core/components/tabs/Tabs_Controller.php
+++ b/wp-content/themes/core/components/tabs/Tabs_Controller.php
@@ -152,6 +152,7 @@ class Tabs_Controller extends Abstract_Controller {
 			self::LAYOUT             => self::LAYOUT_HORIZONTAL,
 			self::TABS               => new Tab_Collection(),
 			self::TAB_BUTTON_CLASSES => [],
+			self::TAB_PANEL_CLASSES  => [],
 			self::TOGGLE_CLASSES     => [],
 		];
 	}


### PR DESCRIPTION
https://moderntribe.atlassian.net/browse/SQONE-609

## What does this do/fix?

- Fixes a regression that completely removed the type setting of a property in the Tabs Controller.

```
Whoops\Exception\ErrorException: Undefined array key &quot;tab_panel_classes&quot; in file /application/www/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php on line 39
Stack trace:
  1. Whoops\Exception\ErrorException-&gt;() /application/www/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php:39
  2. Whoops\Run-&gt;handleError() /application/www/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php:39
  3. Tribe\Project\Templates\Components\Abstract_Controller-&gt;parse_args() /application/www/wp-content/themes/core/components/tabs/Tabs_Controller.php:70
  4. Tribe\Project\Templates\Components\tabs\Tabs_Controller-&gt;__construct() /application/www/vendor/php-di/php-di/src/Definition/Resolver/ObjectCreator.php:143
  5. DI\Definition\Resolver\ObjectCreator-&gt;createInstance() /application/www/vendor/php-di/php-di/src/Definition/Resolver/ObjectCreator.php:71
  6. DI\Definition\Resolver\ObjectCreator-&gt;resolve() /application/www/vendor/php-di/php-di/src/Definition/Resolver/ResolverDispatcher.php:71
  7. DI\Definition\Resolver\ResolverDispatcher-&gt;resolve() /application/www/vendor/php-di/php-di/src/Container.php:390
  8. DI\Container-&gt;resolveDefinition() /application/www/vendor/php-di/php-di/src/Container.php:199
  9. DI\Container-&gt;make() /application/www/wp-content/plugins/core/src/Templates/Components/Abstract_Controller.php:21
 10. Tribe\Project\Templates\Components\Abstract_Controller-&gt;factory() /application/www/wp-content/themes/core/components/tabs/tabs.php:8
 11. require() /application/www/wp/wp-includes/template.php:772
 12. load_template() /application/www/wp/wp-includes/template.php:716
 13. locate_template() /application/www/wp/wp-includes/general-template.php:204
 14. get_template_part() /application/www/wp-content/themes/core/components/blocks/tabs/tabs.php:22
 15. require() /application/www/wp/wp-includes/template.php:772
 16. load_template() /application/www/wp/wp-includes/template.php:716
 17. locate_template() /application/www/wp/wp-includes/general-template.php:204
 18. get_template_part() /application/www/wp-content/themes/core/blocks/tabs/tabs.php:13
 19. require() /application/www/wp/wp-includes/template.php:772
 20. load_template() /application/www/wp/wp-includes/template.php:716
 21. locate_template() /application/www/wp/wp-includes/general-template.php:204
 22. get_template_part() /application/www/vendor/moderntribe/tribe-libs/src/ACF/Block_Renderer.php:28
 23. Tribe\Libs\ACF\Block_Renderer-&gt;render_template() /application/www/wp-content/plugins/core/src/Blocks/Blocks_Subscriber.php:29
 24. Tribe\Project\Blocks\Blocks_Subscriber-&gt;Tribe\Project\Blocks\{closure}() /application/www/wp/wp-includes/class-wp-hook.php:309
 25. WP_Hook-&gt;apply_filters() /application/www/wp/wp-includes/class-wp-hook.php:331
 26. WP_Hook-&gt;do_action() /application/www/wp/wp-includes/plugin.php:474
 27. do_action() /application/www/vendor/moderntribe/tribe-libs/src/ACF/Block_Config.php:71
 28. Tribe\Libs\ACF\Block_Config-&gt;Tribe\Libs\ACF\{closure}() /application/www/wp-content/plugins/advanced-custom-fields-pro/pro/blocks.php:424
 29. acf_render_block() /application/www/wp-content/plugins/advanced-custom-fields-pro/pro/blocks.php:367
 30. acf_rendered_block() /application/www/wp-content/plugins/advanced-custom-fields-pro/pro/blocks.php:680
 31. acf_ajax_fetch_block() /application/www/wp/wp-includes/class-wp-hook.php:307
 32. WP_Hook-&gt;apply_filters() /application/www/wp/wp-includes/class-wp-hook.php:331
 33. WP_Hook-&gt;do_action() /application/www/wp/wp-includes/plugin.php:474
 34. do_action() /application/www/wp/wp-admin/admin-ajax.php:187
```

## QA

- The notice/error will no longer appear

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests.
- [ ] No, I need help figuring out how to write the tests.

