### PR TITLE
Bugfix: Follow component social icon CSS class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.09
+* Fixed: Regression wrong social icon classes being outputted for the Follow component. Icons now show properly show up.
 * Added: Git ignore [lefthook-local.yml](https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md#local-config) so developers can customize the version of PHP calling the script if required.
 * Fixed: Regression from removing default typing of tab panel classes property
 

--- a/wp-content/themes/core/components/follow/Follow_Controller.php
+++ b/wp-content/themes/core/components/follow/Follow_Controller.php
@@ -40,7 +40,7 @@ class Follow_Controller extends Abstract_Controller {
 			$link        = new Social_Link();
 			$link->title = $this->get_label( $social_site );
 			$link->url   = $url;
-			$link->class = $social_site;
+			$link->class = str_replace( 'social_', '', $social_site );
 
 			return $link->toArray();
 		}, $this->social_keys ) );


### PR DESCRIPTION
## What does this do/fix?

- Using the Follow component would not output any social icons because the CSS class names were incorrect.

## QA

The icons now show up when using the Follow component:

![image](https://user-images.githubusercontent.com/1066195/191604230-4b0b25f6-0f9c-4283-a69c-98643b04dec0.png)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because, well it probably could have used them.
- [ ] No, I need help figuring out how to write the tests.

