### PR TITLE
Bugfix: Single Controller `get_author_id()` now returns an integer type instead of a string.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.09
+* Fixed: Single Controller `get_author_id()` now returns an integer type instead of a string.
 * Fixed: Regression wrong social icon classes being outputted for the Follow component. Icons now show properly show up.
 * Added: Git ignore [lefthook-local.yml](https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md#local-config) so developers can customize the version of PHP calling the script if required.
 * Fixed: Regression from removing default typing of tab panel classes property

--- a/wp-content/themes/core/routes/single/Single_Controller.php
+++ b/wp-content/themes/core/routes/single/Single_Controller.php
@@ -94,10 +94,10 @@ class Single_Controller extends Abstract_Controller {
 		return $this->sidebar_id;
 	}
 
-	public function get_author_id(): string {
+	public function get_author_id(): int {
 		global $post;
 
-		return $post->post_author;
+		return (int) $post->post_author;
 	}
 
 	protected function defaults(): array {


### PR DESCRIPTION
## What does this do/fix?

- Although WP Query says the `post_author` property is a string for compatibility reasons, functions using it expect it to be an integer.

I'm not sure why PHPSTAN allowed this through in the first place?

## QA

![image](https://user-images.githubusercontent.com/1066195/192023845-39923cbb-8f61-4965-83f2-c8c140a4a195.png)



