### PR TITLE
Add styles for the default consent field from Gravity Forms.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 * Fixed: Regression wrong social icon classes being outputted for the Follow component. Icons now show properly show up.
 * Added: Git ignore [lefthook-local.yml](https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md#local-config) so developers can customize the version of PHP calling the script if required.
 * Fixed: Regression from removing default typing of tab panel classes property
+* Added: Gravity Forms style support the consent field.
 
 ## 2022.08
 * Updated: Swiper to version `8.3.2`.

--- a/wp-content/themes/core/components/blocks/links/css/links.pcss
+++ b/wp-content/themes/core/components/blocks/links/css/links.pcss
@@ -68,7 +68,6 @@
 
 	/* CASE: Layout Inline */
 	.c-block--layout-inline & {
-
 		@media (--viewport-full) {
 			margin-bottom: 0;
 			padding-right: var(--grid-gutter);
@@ -150,11 +149,11 @@
 	}
 
 	.c-block--layout-stacked & {
+
 		&:first-child {
 			@media (--viewport-full) {
 				padding-bottom: var(--spacer-40);
 			}
-
 		}
 
 		~ .b-links__list-item {

--- a/wp-content/themes/core/integrations/gravity-forms/css/controls/consent.pcss
+++ b/wp-content/themes/core/integrations/gravity-forms/css/controls/consent.pcss
@@ -1,0 +1,9 @@
+.ginput_container_consent {
+	@mixin form-control-radio-checkbox-base;
+	@mixin form-control-radio-checkbox;
+	@mixin form-control-checkbox;
+
+	input[type="checkbox"]:checked + label:after {
+		content: var(--icon-check);
+	}
+}

--- a/wp-content/themes/core/integrations/gravity-forms/index.pcss
+++ b/wp-content/themes/core/integrations/gravity-forms/index.pcss
@@ -23,6 +23,7 @@
 @import "css/controls/file.pcss";
 @import "css/controls/hidden.pcss";
 @import "css/controls/lists.pcss";
+@import "css/controls/consent.pcss";
 @import "css/validation/required.pcss";
 @import "css/validation/success.pcss";
 @import "css/validation/error.pcss";


### PR DESCRIPTION
## What does this do/fix?

Adds `pcss` support for the consent field that comes out of the box with GF.

(yes, I noticed I misspelled the branch name lol)

## QA

Screenshots/video:
![Screenshot on 2022-09-26 at 12-55-24](https://user-images.githubusercontent.com/766503/192346903-a5fab959-9c27-40c3-a657-8805a90aac51.png)


## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests.
- [ ] No, I need help figuring out how to write the tests.

