### PR TITLE
Update wordpress-stubs.patch to match the latest version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2022.10
+* Fixed: wordpress-stubs.patch failing to patch on php-stubs/wordpress-stubs v6.0.2
+
 ## 2022.09
 * Fixed: Single Controller `get_author_id()` now returns an integer type instead of a string.
 * Fixed: Regression wrong social icon classes being outputted for the Follow component. Icons now show properly show up.

--- a/composer.lock
+++ b/composer.lock
@@ -6193,16 +6193,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.0.1",
+            "version": "v6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "e04781a84e364615a7b5f70fdc345c8253ca5b8f"
+                "reference": "8f696e429e375ef40a841ecf5ac686ff7437b4dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/e04781a84e364615a7b5f70fdc345c8253ca5b8f",
-                "reference": "e04781a84e364615a7b5f70fdc345c8253ca5b8f",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/8f696e429e375ef40a841ecf5ac686ff7437b4dc",
+                "reference": "8f696e429e375ef40a841ecf5ac686ff7437b4dc",
                 "shasum": ""
             },
             "replace": {
@@ -6234,9 +6234,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.0.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.0.2"
             },
-            "time": "2022-07-15T11:10:45+00:00"
+            "time": "2022-09-30T17:24:55+00:00"
         },
         {
             "name": "php-stubs/wordpress-tests-stubs",

--- a/dev/patches/wordpress-stubs.patch
+++ b/dev/patches/wordpress-stubs.patch
@@ -1,29 +1,29 @@
---- /vendor/php-stubs/wordpress-stubs/wordpress-stubs.php.old	2022-04-05 21:38:44.000000000 -0400
-+++ /vendor/php-stubs/wordpress-stubs/wordpress-stubs.php	2022-04-05 21:39:32.000000000 -0400
-@@ -114962,7 +114962,7 @@
-      * @param string $password Plain text user password to hash
-      * @return string The hash string of the password
-      */
--    function wp_hash_password($password)
-+    function __wp_hash_password($password)
-     {
-     }
-     /**
-@@ -114987,7 +114987,7 @@
-      * @param string|int $user_id  Optional. User ID.
-      * @return bool False, if the $password does not match the hashed password
-      */
--    function wp_check_password($password, $hash, $user_id = '')
-+    function __wp_check_password($password, $hash, $user_id = '')
-     {
-     }
-     /**
-@@ -115040,7 +115040,7 @@
-      * @param string $password The plaintext new user password
-      * @param int    $user_id  User ID
-      */
--    function wp_set_password($password, $user_id)
-+    function __wp_set_password($password, $user_id)
-     {
-     }
-     /**
+--- /vendor/php-stubs/wordpress-stubs/wordpress-stubs.php.old	2022-10-06 10:48:50.178969468 -0600
++++ /vendor/php-stubs/wordpress-stubs/wordpress-stubs.php	2022-10-06 10:49:29.275733625 -0600
+@@ -114963,7 +114963,7 @@
+  * @param string $password Plain text user password to hash
+  * @return string The hash string of the password
+  */
+-function wp_hash_password($password)
++function __wp_hash_password($password)
+ {
+ }
+ /**
+@@ -114988,7 +114988,7 @@
+  * @param string|int $user_id  Optional. User ID.
+  * @return bool False, if the $password does not match the hashed password
+  */
+-function wp_check_password($password, $hash, $user_id = '')
++function __wp_check_password($password, $hash, $user_id = '')
+ {
+ }
+ /**
+@@ -115041,7 +115041,7 @@
+  * @param string $password The plaintext new user password
+  * @param int    $user_id  User ID
+  */
+-function wp_set_password($password, $user_id)
++function __wp_set_password($password, $user_id)
+ {
+ }
+ /**


### PR DESCRIPTION
## What does this do/fix?

- [v6.0.2 of the php-stubs/wordpress-stubs](https://github.com/php-stubs/wordpress-stubs/releases/tag/v6.0.2) package was released and the `wordpress-stubs.patch` was no longer able to patch the conflicting functions with the [roots/wp-password-bcrypt](https://github.com/roots/wp-password-bcrypt) package.


## QA

- A `composer update` should now properly patch the wordpress-stubs package.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a patch file update for an external library.
- [ ] No, I need help figuring out how to write the tests.

