### PR TITLE
Update/misc js updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.10
+* Updated: Switched to an mT-owned version of a11y-dialog w/ misc bug fixes and update body lock/unlock scripts to address CSS-defined `scroll-behavior: scroll`. 
 * Fixed: wordpress-stubs.patch failing to patch on php-stubs/wordpress-stubs v6.0.2 (again)
 * Updated: WordPres core to v6.0.3
 * Updated: Plugins Gravity Forms v2.6.7, Limit Login Attempts Reloaded: v2.25.8, Yoast SEO: v19.8

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.3",
+    "@moderntribe/a11y-dialog": "^5.3.0",
     "@types/react": "^16.9.11",
     "@vimeo/player": "^2.15.3",
     "classnames": "^2.2.6",
@@ -86,7 +87,6 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
-    "mt-a11y-dialog": "^5.1.1",
     "object-hash": "^2.2.0",
     "object-to-formdata": "^2.1.2",
     "prop-types": "^15.7.2",

--- a/wp-content/themes/core/assets/js/src/utils/dom/body-lock.js
+++ b/wp-content/themes/core/assets/js/src/utils/dom/body-lock.js
@@ -1,9 +1,10 @@
 import * as tests from '../tests';
 
 const browser = tests.browserTests();
-let scroll = 0;
 const scroller = browser.ie || browser.firefox || browser.safari || browser.ios || ( browser.chrome && ! browser.edge ) ? document.documentElement : document.body;
 let locked = false;
+let scroll = 0;
+let scrollBehavior = '';
 
 /**
  * @function isLocked
@@ -19,12 +20,13 @@ const isLocked = () => locked;
  */
 
 const lock = () => {
-	const style = document.body.style;
 	scroll = scroller.scrollTop;
+	scrollBehavior = document.documentElement.style.scrollBehavior;
 	locked = true;
 
-	style.position = 'fixed';
-	style.marginTop = `-${ scroll }px`;
+	document.documentElement.style.scrollBehavior = 'auto';
+	document.body.style.position = 'fixed';
+	document.body.style.marginTop = `-${ scroll }px`;
 };
 
 /**
@@ -33,12 +35,11 @@ const lock = () => {
  */
 
 const unlock = () => {
-	const style = document.body.style;
-
-	style.position = 'static';
-	style.marginTop = '0px';
+	document.body.style.position = 'static';
+	document.body.style.marginTop = '0px';
 
 	scroller.scrollTop = scroll;
+	document.documentElement.style.scrollBehavior = scrollBehavior;
 	locked = false;
 };
 

--- a/wp-content/themes/core/components/dialog/js/dialog.js
+++ b/wp-content/themes/core/components/dialog/js/dialog.js
@@ -3,7 +3,7 @@
  * @description JavaScript that drives Dialog
  */
 
-import A11yDialog from 'mt-a11y-dialog';
+import A11yDialog from '@moderntribe/a11y-dialog';
 import * as tools from 'utils/tools';
 import { trigger } from 'utils/events';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,6 +1462,11 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz#0300943770e04231041a51bd39f0439b5c7ab4f0"
   integrity sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==
 
+"@moderntribe/a11y-dialog@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@moderntribe/a11y-dialog/-/a11y-dialog-5.3.0.tgz#7f3d98e5fbc6c41bab0b3da0ed61eece22e27549"
+  integrity sha512-wLHjaiytB9EfGHYy69J1gAz+DPCB+HEUpViPZVdPYfZzRlJjLArXPxVnupuoavr4eige8PX31MKYJrdjPZKcdQ==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -10160,11 +10165,6 @@ ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-mt-a11y-dialog@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/mt-a11y-dialog/-/mt-a11y-dialog-5.1.1.tgz#a71c47866f8ecf1b1a3a17fe4d46bacefc7040a0"
-  integrity sha512-xwHReUDOMHfAgVY1kYdjCJIxFzsEpHYS4UOC/+64fECE5DpV/6Pjz/+S9FWorBeTjxUjtHBPfn0hShbvKSCyZg==
 
 multicast-dns@^7.2.4:
   version "7.2.4"


### PR DESCRIPTION
## What does this do/fix?
Updates to our body lock/unlock utility script to address the new(ish) smooth scroll behavior available in browsers and to point to an MT-owned (and updated) copy of the accessible dialog library. 

Note that the changes to the body lock/unlock script only affect sites that set `scroll-behavior: smooth` on the html or body elements to enable smooth scrolling for the whole document.

The a11y-dialog update is something that should be addressed on any project using the script as the previous repo/version has a bug related to the scrollTop not being calculated correctly in newer versions of Safari. 

## QA

These issues were raised via a ticket in the Harvard project.
- [HMNT22-58](https://moderntribe.atlassian.net/browse/HMNT22-58)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because this is a JS update.
- [ ] No, I need help figuring out how to write the tests.

