### PR TITLE
Bugfix: Remove Yoast filter 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.10
+* Removed: Yoast hook that was removing the schema to be output.
 * Updated: Switched to an mT-owned version of a11y-dialog w/ misc bug fixes and update body lock/unlock scripts to address CSS-defined `scroll-behavior: scroll`. 
 * Fixed: wordpress-stubs.patch failing to patch on php-stubs/wordpress-stubs v6.0.2 (again)
 * Updated: WordPres core to v6.0.3

--- a/wp-content/plugins/core/src/Integrations/Yoast_SEO/Yoast_SEO_Subscriber.php
+++ b/wp-content/plugins/core/src/Integrations/Yoast_SEO/Yoast_SEO_Subscriber.php
@@ -14,9 +14,6 @@ class Yoast_SEO_Subscriber extends Abstract_Subscriber {
 		add_filter( 'wpseo_twitter_image_size', function ( $size ) {
 			return $this->container->get( Open_Graph::class )->customize_wpseo_twitter_image_size( (string) $size );
 		}, 10, 1 );
-
-		// Remove WP SEO json-ld output in favor of the included functions
-		add_filter( 'wpseo_json_ld_output', '__return_false' );
 	}
 
 }


### PR DESCRIPTION
## What does this do/fix?
Removes `wpseo_json_ld_output` Yoast hook. This was removing the schema output.

## Tests

Does this have tests?

- [ ] Yes
- [ ] No, this doesn't need tests because ...
- [X] No, I need help figuring out how to write the tests.

