### PR TITLE
Feature: Gallery Slider/Grid Block Collection Updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.10
+* Updated: Tribe Libs to v4.2
+* Updated: Gallery Slider/Grid blocks to use the new Gallery Field Model Collection & code clean up
+* Updated: Added `TRIBE_ENABLE_SVG_INLINE_STORAGE` define stub to local-config-sample.php
 * Removed: Yoast hook that was removing the schema to be output.
 * Updated: Switched to an mT-owned version of a11y-dialog w/ misc bug fixes and update body lock/unlock scripts to address CSS-defined `scroll-behavior: scroll`. 
 * Fixed: wordpress-stubs.patch failing to patch on php-stubs/wordpress-stubs v6.0.2 (again)

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
     "johnpbloch/wordpress-core-installer": "2.0.*",
     "moderntribe/acf-image-select": "dev-master",
     "moderntribe/acf-menu-chooser": "^1.1",
-    "moderntribe/tribe-libs": "^4.0.3",
+    "moderntribe/tribe-libs": "^4.2",
     "nickford/acf-swatch": "1.0.7",
     "php-ds/php-ds": "^1.4",
     "php-http/client-common": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ac8f4d59f966a2df68b8ce2c710cef5",
+    "content-hash": "a79691dd5736387aa413dbeb16b202d9",
     "packages": [
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
@@ -70,16 +70,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.238.6",
+            "version": "3.240.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "79a76b438bd20ae687394561b4f28cb6c10db08e"
+                "reference": "34c6bf82f337cadf31475c88ca70e8302afc624b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/79a76b438bd20ae687394561b4f28cb6c10db08e",
-                "reference": "79a76b438bd20ae687394561b4f28cb6c10db08e",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/34c6bf82f337cadf31475c88ca70e8302afc624b",
+                "reference": "34c6bf82f337cadf31475c88ca70e8302afc624b",
                 "shasum": ""
             },
             "require": {
@@ -158,9 +158,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.238.6"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.240.1"
             },
-            "time": "2022-10-17T18:17:10+00:00"
+            "time": "2022-10-24T19:03:23+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -1406,22 +1406,24 @@
         },
         {
             "name": "moderntribe/tribe-libs",
-            "version": "4.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moderntribe/tribe-libs.git",
-                "reference": "c0b157e05e4198e2fd3dd9bef95e2ebcab10bbc2"
+                "reference": "04bb57ec334d2cbd514456ddcc13132e76d6fe82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moderntribe/tribe-libs/zipball/c0b157e05e4198e2fd3dd9bef95e2ebcab10bbc2",
-                "reference": "c0b157e05e4198e2fd3dd9bef95e2ebcab10bbc2",
+                "url": "https://api.github.com/repos/moderntribe/tribe-libs/zipball/04bb57ec334d2cbd514456ddcc13132e76d6fe82",
+                "reference": "04bb57ec334d2cbd514456ddcc13132e76d6fe82",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "enshrined/svg-sanitize": "^0.15",
+                "ext-dom": "*",
                 "ext-json": "*",
+                "ext-libxml": "*",
                 "ext-simplexml": "*",
                 "ext-zlib": "*",
                 "filp/whoops": "^2.2@dev",
@@ -1467,14 +1469,17 @@
             "require-dev": {
                 "automattic/phpcs-neutron-standard": "^1.5",
                 "automattic/vipwpcs": "^2.0",
+                "brain/monkey": "2.*",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || ^0.7.0",
                 "fakerphp/faker": "^1.20",
                 "lucatume/wp-browser": "^3.1",
                 "nelexa/zip": "^4.0",
                 "nette/utils": "^3.2 || ^4.0",
-                "phpcompatibility/php-compatibility": "10.x-dev#c23e20c as 9.3.5",
+                "phpcompatibility/php-compatibility": "10.x-dev#a726377 as 9.3.5",
                 "phpcompatibility/phpcompatibility-wp": "^2.0",
+                "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
                 "phpunit/phpunit": "^8.0 || ^9.0",
                 "sirbrillig/phpcs-variable-analysis": "^2.0",
                 "squizlabs/php_codesniffer": "^3.4.2",
@@ -1533,9 +1538,9 @@
             "description": "A library for use on Modern Tribe service projects.",
             "support": {
                 "issues": "https://github.com/moderntribe/tribe-libs/issues",
-                "source": "https://github.com/moderntribe/tribe-libs/tree/4.1.0"
+                "source": "https://github.com/moderntribe/tribe-libs/tree/4.2.0"
             },
-            "time": "2022-10-03T15:40:06+00:00"
+            "time": "2022-10-25T16:43:09+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4925,23 +4930,23 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "ade2b3bbfb776f27f0558e26eed43b5d9fe1b392"
+                "reference": "d9d313a36c872fd6ee06d9a6cbcf713eaa40f024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/ade2b3bbfb776f27f0558e26eed43b5d9fe1b392",
-                "reference": "ade2b3bbfb776f27f0558e26eed43b5d9fe1b392",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/d9d313a36c872fd6ee06d9a6cbcf713eaa40f024",
+                "reference": "d9d313a36c872fd6ee06d9a6cbcf713eaa40f024",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^10",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.3",
@@ -4996,7 +5001,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.5"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.6"
             },
             "funding": [
                 {
@@ -5012,7 +5017,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-07T09:01:28+00:00"
+            "time": "2022-10-20T09:10:12+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -5137,7 +5142,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.36.0",
+            "version": "v9.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -5192,7 +5197,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.36.0",
+            "version": "v9.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -5238,7 +5243,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.36.0",
+            "version": "v9.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -5286,7 +5291,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.36.0",
+            "version": "v9.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -5332,16 +5337,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.36.0",
+            "version": "v9.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "51c61f2880340102edfdf08b3bc4f0c6a33a54c1"
+                "reference": "f194a3b1435ed4f2542d127efb8652c7d41980ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/51c61f2880340102edfdf08b3bc4f0c6a33a54c1",
-                "reference": "51c61f2880340102edfdf08b3bc4f0c6a33a54c1",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/f194a3b1435ed4f2542d127efb8652c7d41980ea",
+                "reference": "f194a3b1435ed4f2542d127efb8652c7d41980ea",
                 "shasum": ""
             },
             "require": {
@@ -5398,7 +5403,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-14T18:22:17+00:00"
+            "time": "2022-10-24T09:54:34+00:00"
         },
         {
             "name": "larapack/dd",
@@ -6421,16 +6426,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
@@ -6467,26 +6472,27 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2021-02-15T10:24:51+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
@@ -6521,13 +6527,14 @@
                 "compatibility",
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-12-30T16:37:40+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -6575,16 +6582,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.11.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "7d1e81213b0c7eb8d5a9f524456cbc2778ed5c65"
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d1e81213b0c7eb8d5a9f524456cbc2778ed5c65",
-                "reference": "7d1e81213b0c7eb8d5a9f524456cbc2778ed5c65",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/33aefcdab42900e36366d0feab6206e2dd68f947",
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947",
                 "shasum": ""
             },
             "require": {
@@ -6614,22 +6621,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.11.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.13.0"
             },
-            "time": "2022-10-14T13:32:28+00:00"
+            "time": "2022-10-21T09:57:39+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.10",
+            "version": "1.8.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "0c4459dc42c568b818b3f25186589f3acddc1823"
+                "reference": "46e223dd68a620da18855c23046ddb00940b4014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0c4459dc42c568b818b3f25186589f3acddc1823",
-                "reference": "0c4459dc42c568b818b3f25186589f3acddc1823",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/46e223dd68a620da18855c23046ddb00940b4014",
+                "reference": "46e223dd68a620da18855c23046ddb00940b4014",
                 "shasum": ""
             },
             "require": {
@@ -6659,7 +6666,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.10"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.11"
             },
             "funding": [
                 {
@@ -6675,7 +6682,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-17T14:23:35+00:00"
+            "time": "2022-10-24T15:45:13+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",

--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -30,7 +30,7 @@ define( 'HMR_DEV', false );
 
 /*
  * Theme service worker
- * 
+ *
  * If your project needs to make use of the theme service worker, enable it here.
  */
 // define( 'ENABLE_THEME_SERVICE_WORKER', true );
@@ -53,6 +53,14 @@ define( 'ASSET_VERSION_TIMESTAMP', true );
  * If you enable Whoops, the Whoops error library will be used to provide better/prettier error logging.
  */
 define( 'WHOOPS_ENABLE', true );
+
+/*
+ * Disable inline SVG storage, newly uploaded SVG's will no longer have
+ * their markup stored in post meta.
+ *
+ * @link https://github.com/moderntribe/tribe-libs/tree/4.x/src/Media#fetching-stored-svg-markup
+ */
+//define( 'TRIBE_ENABLE_SVG_INLINE_STORAGE', false );
 
 /*
  * Glomar

--- a/wp-content/plugins/core/src/Blocks/Types/Gallery_Grid/Gallery_Grid_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Gallery_Grid/Gallery_Grid_Model.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Project\Blocks\Types\Gallery_Grid;
 
+use Tribe\Libs\Field_Models\Collections\Gallery_Collection;
 use Tribe\Project\Blocks\Types\Base_Model;
 use Tribe\Project\Templates\Components\blocks\gallery_grid\Gallery_Grid_Controller;
 
@@ -20,7 +21,7 @@ class Gallery_Grid_Model extends Base_Model {
 			Gallery_Grid_Controller::LEAD_IN        => $this->get( Gallery_Grid::LEAD_IN, '' ),
 			Gallery_Grid_Controller::TITLE          => $this->get( Gallery_Grid::TITLE, '' ),
 			Gallery_Grid_Controller::DESCRIPTION    => $this->get( Gallery_Grid::DESCRIPTION, '' ),
-			Gallery_Grid_Controller::GALLERY_IMAGES => $this->get( Gallery_Grid::GALLERY_IMAGES, [] ),
+			Gallery_Grid_Controller::GALLERY_IMAGES => Gallery_Collection::create( $this->get( Gallery_Grid::GALLERY_IMAGES, [] ) ),
 			Gallery_Grid_Controller::COLUMNS        => $this->get( Gallery_Grid::COLUMNS, Gallery_Grid::COLUMNS_THREE ),
 			Gallery_Grid_Controller::USE_SLIDESHOW  => $this->get( Gallery_Grid::USE_SLIDESHOW, false ),
 		];

--- a/wp-content/plugins/core/src/Blocks/Types/Gallery_Slider/Gallery_Slider_Model.php
+++ b/wp-content/plugins/core/src/Blocks/Types/Gallery_Slider/Gallery_Slider_Model.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Project\Blocks\Types\Gallery_Slider;
 
+use Tribe\Libs\Field_Models\Collections\Gallery_Collection;
 use Tribe\Libs\Field_Models\Models\Link;
 use Tribe\Project\Blocks\Types\Base_Model;
 use Tribe\Project\Templates\Components\blocks\gallery_slider\Gallery_Slider_Controller;
@@ -24,7 +25,7 @@ class Gallery_Slider_Model extends Base_Model {
 			Gallery_Slider_Controller::TITLE           => $this->get( Gallery_Slider::TITLE, '' ),
 			Gallery_Slider_Controller::DESCRIPTION     => $this->get( Gallery_Slider::DESCRIPTION, '' ),
 			Gallery_Slider_Controller::CTA             => new Link( $this->get( Gallery_Slider::CTA, [] ) ),
-			Gallery_Slider_Controller::GALLERY         => $this->get( Gallery_Slider::GALLERY, [] ),
+			Gallery_Slider_Controller::GALLERY         => Gallery_Collection::create( $this->get( Gallery_Slider::GALLERY, [] ) ),
 			Gallery_Slider_Controller::IMAGE_RATIO     => $this->get( Gallery_Slider::IMAGE_RATIO, Gallery_Slider::FIXED ),
 			Gallery_Slider_Controller::CAPTION_DISPLAY => $this->get( Gallery_Slider::CAPTION_DISPLAY, Gallery_Slider::CAPTION_DISPLAY_SHOW ),
 		];


### PR DESCRIPTION
## What does this do/fix?

* Updated: Tribe Libs to v4.2
* Updated: Gallery Slider/Grid blocks to use the new [Gallery Field Model Collection](https://github.com/moderntribe/tribe-libs/pull/136) & code clean up
* Updated: Added `TRIBE_ENABLE_SVG_INLINE_STORAGE` define stub to local-config-sample.php [New SVG storage feature](https://github.com/moderntribe/tribe-libs/pull/135)


## QA

Both blocks functioning as before
![image](https://user-images.githubusercontent.com/1066195/197864610-5670f088-1f25-4c19-8307-7f3577d7f3f1.png)

Gallery Grid Slideshow
![image](https://user-images.githubusercontent.com/1066195/197864730-5f348ae8-6b85-4355-b397-8958ed2b5aca.png)


## Tests

Does this have tests?

- [ ] Yes
- [x] No, because it's a block update.
- [ ] No, I need help figuring out how to write the tests.

