### PR TITLE
Add .deploy-ignore file and update deploy workflows

### DIFF
--- a/.deploy-ignore
+++ b/.deploy-ignore
@@ -2,8 +2,8 @@
 # This file is run via GitHub workflows, see the .github/workflows folder.
 
 # This file and any include files.
-.rsyncignore
-.rsyncinclude
+.deploy-ignore
+.deploy-include
 
 # Large/disallowed file types on WP Engine
 *.hqx

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -108,7 +108,7 @@ jobs:
       # Rsync plugin and theme files
       - name: Sync Build WP-CONTENT folder to Deploy directory
         run: |
-          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.rsyncignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
+          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.deploy-ignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
             --exclude=dev \
             --exclude=dev_components \
             --exclude=docs \

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -94,7 +94,7 @@ jobs:
           git config user.email "devops@tri.be"
           git config user.name "devops"
 
-      # Rsync wordpress
+      # Rsync WordPress
       - name: Sync Build WP folder to Deploy directory
         run: |
           rsync -rpv --delete ${{env.BUILD_FOLDER}}/wp/ ${{env.DEPLOY_FOLDER}} \
@@ -108,14 +108,7 @@ jobs:
       # Rsync plugin and theme files
       - name: Sync Build WP-CONTENT folder to Deploy directory
         run: |
-          rsync -rpv --delete ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
-            --exclude=.git \
-            --exclude=.gitmodules \
-            --exclude=.gitignore \
-            --exclude=.htaccess \
-            --exclude=.babelrc \
-            --exclude=.editorconfig \
-            --exclude=.eslintrc \
+          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.rsyncignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
             --exclude=dev \
             --exclude=dev_components \
             --exclude=docs \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -108,7 +108,7 @@ jobs:
       # Rsync plugin and theme files
       - name: Sync Build WP-CONTENT folder to Deploy directory
         run: |
-          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.rsyncignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
+          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.deploy-ignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
             --exclude=dev \
             --exclude=dev_components \
             --exclude=docs \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -94,7 +94,7 @@ jobs:
           git config user.email "devops@tri.be"
           git config user.name "devops"
 
-      # Rsync wordpress
+      # Rsync WordPress
       - name: Sync Build WP folder to Deploy directory
         run: |
           rsync -rpv --delete ${{env.BUILD_FOLDER}}/wp/ ${{env.DEPLOY_FOLDER}} \
@@ -108,14 +108,7 @@ jobs:
       # Rsync plugin and theme files
       - name: Sync Build WP-CONTENT folder to Deploy directory
         run: |
-          rsync -rpv --delete ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
-            --exclude=.git \
-            --exclude=.gitmodules \
-            --exclude=.gitignore \
-            --exclude=.htaccess \
-            --exclude=.babelrc \
-            --exclude=.editorconfig \
-            --exclude=.eslintrc \
+          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.rsyncignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
             --exclude=dev \
             --exclude=dev_components \
             --exclude=docs \

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -108,7 +108,7 @@ jobs:
       # Rsync plugin and theme files
       - name: Sync Build WP-CONTENT folder to Deploy directory
         run: |
-          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.rsyncignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
+          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.deploy-ignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
             --exclude=dev \
             --exclude=dev_components \
             --exclude=docs \

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -94,7 +94,7 @@ jobs:
           git config user.email "devops@tri.be"
           git config user.name "devops"
 
-      # Rsync wordpress
+      # Rsync WordPress
       - name: Sync Build WP folder to Deploy directory
         run: |
           rsync -rpv --delete ${{env.BUILD_FOLDER}}/wp/ ${{env.DEPLOY_FOLDER}} \
@@ -108,14 +108,7 @@ jobs:
       # Rsync plugin and theme files
       - name: Sync Build WP-CONTENT folder to Deploy directory
         run: |
-          rsync -rpv --delete ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
-            --exclude=.git \
-            --exclude=.gitmodules \
-            --exclude=.gitignore \
-            --exclude=.htaccess \
-            --exclude=.babelrc \
-            --exclude=.editorconfig \
-            --exclude=.eslintrc \
+          rsync -rpv --delete --exclude-from="${{env.BUILD_FOLDER}}/.rsyncignore" ${{env.BUILD_FOLDER}}/wp-content ${{env.DEPLOY_FOLDER}} \
             --exclude=dev \
             --exclude=dev_components \
             --exclude=docs \

--- a/.rsyncignore
+++ b/.rsyncignore
@@ -1,0 +1,100 @@
+# Files and folders that should never be deployed to a web hosting environment via rsync.
+# This file is run via GitHub workflows, see the .github/workflows folder.
+
+# This file and any include files.
+.rsyncignore
+.rsyncinclude
+
+# Large/disallowed file types on WP Engine
+*.hqx
+*.bin
+*.exe
+*.dll
+*.deb
+*.dmg
+*.iso
+*.img
+*.msi
+*.msp
+*.msm
+*.mid
+*.midi
+*.kar
+*.mp3
+*.ogg
+*.m4a
+*.ra
+*.3gpp
+*.3gp
+*.mp4
+*.mpeg
+*.mpg
+*.mov
+*.webm
+*.flv
+*.m4v
+*.mng
+*.asx
+*.asf
+*.wmv
+*.avi
+
+# IDE configuration
+.editorconfig
+.idea/
+.vscode/
+
+# Build tools
+.babelrc
+.eslintignore
+.eslintrc
+.nvmrc
+.stylelintignore
+.stylelintrc.json
+Gruntfile.js
+babel.config.js
+bower.json
+gulpfile.js
+jest.config.json
+jest.setup.js
+package.json
+yarn.lock
+
+# Frontend Source files
+*.pcss
+*.scss
+
+# Quality tools
+codecov.yml
+phpcs.xml
+phpcs.xml.dist
+phpstan-baseline.neon
+phpstan.neon
+phpstan.neon.dist
+psalm.xml
+
+# Git
+*.gitignore
+*.gitmodules
+*.git
+*.gitkeep
+*.github
+
+# Packages
+*.7z
+*.dmg
+*.gz
+*.bz2
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+*.tgz
+
+# Log files and databases
+*.log
+*.sql
+
+# Apache
+.htaccess

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2022.12
+* Added: .rsyncignore file and updated deployments to use it to decide which file type should never get synced and deployed to web servers.
+
 ## 2022.10
 * Removed: Yoast hook that was removing the schema to be output.
 * Updated: Switched to an mT-owned version of a11y-dialog w/ misc bug fixes and update body lock/unlock scripts to address CSS-defined `scroll-behavior: scroll`. 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2022.12
-* Added: .rsyncignore file and updated deployments to use it to decide which file type should never get synced and deployed to web servers.
+* Added: .deploy-ignore file and updated deployments to use it to decide which file type should never get synced and deployed to web servers.
 
 ## 2022.10
 * Removed: Yoast hook that was removing the schema to be output.


### PR DESCRIPTION
## What does this do/fix?

- Add a single configuration file for all files/folders to ignore when using rsync to sync a built project's wp-content folder.


## QA

Any of these files inside of wp-content should never get deployed to a server.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's GitHub workflow update.
- [ ] No, I need help figuring out how to write the tests.

