### PR TITLE
Add ability to hide taxonomies fields and manual overrides

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2023.01
+* Added: 2 parameters are added to the Post_Loop_Field_Config class. `show_taxonomy_filter` - allows hiding taxonomy filtering fields. `show_override_option` - allow hiding Override fields group for manual query
+
 ## 2022.12
 * Added: .deploy-ignore file and updated deployments to use it to decide which file type should never get synced and deployed to web servers.
 

--- a/dev/tests/tests/integration/Tribe/Project/Blocks/Middleware/Post_Loop/Field_Middleware/PostLoopFieldMiddlewareTest.php
+++ b/dev/tests/tests/integration/Tribe/Project/Blocks/Middleware/Post_Loop/Field_Middleware/PostLoopFieldMiddlewareTest.php
@@ -186,4 +186,140 @@ final class PostLoopFieldMiddlewareTest extends Test_Case {
 		$this->assertArrayNotHasKey( Post_Loop_Field_Middleware::MANUAL_EXCERPT, $field_names );
 	}
 
+	public function test_it_does_not_have_taxonomy_filtering_manual_override() {
+		$block = new class extends Block_Config implements Has_Middleware_Params {
+
+			use With_Field_Prefix;
+
+			public const NAME = 'test_block';
+
+			public const SECTION_CARDS = 's-cards';
+			public const CARD_LIST     = 'card_list';
+
+			public function add_block() {
+				$this->set_block( new Block( self::NAME, [
+					'title' => esc_html__( 'A Test Block', 'tribe' ),
+				] ) );
+			}
+
+			public function add_fields() {
+				// Populated via Block Middleware
+				$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( 'Cards', 'tribe' ), 'accordion' ) );
+			}
+
+			/**
+			 * Config the query post loop field for middleware.
+			 *
+			 * @return array<array{post_loop_field_configs: \Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config[]}>
+			 */
+			public function get_middleware_params(): array {
+				$config              = new Post_Loop_Field_Config();
+				$config->field_name  = self::CARD_LIST;
+				$config->group       = $this->get_section_key( self::SECTION_CARDS );
+				$config->limit_min   = 2;
+				$config->limit_max   = 10;
+
+				$config->show_overwrite_options = false;
+				$config->show_taxonomy_filter   = false;
+
+				return [
+					[
+						Post_Loop_Field_Middleware::MIDDLEWARE_KEY => [
+							$config,
+						],
+					],
+				];
+			}
+
+		};
+
+		$block_field_guard = new Block_Field_Middleware_Guard( new Map( [
+			get_class( $block ) => [
+				Post_Loop_Field_Middleware::class,
+			],
+		] ) );
+
+		$pipeline = $this->container->make( Pipeline::class )
+			->via( 'add_fields' )
+			->through( [
+				new Post_Loop_Field_Middleware( $block_field_guard ),
+			] );
+
+		$processed_block = ( new Add_Fields_Pipeline( $pipeline ) )->process( $block, $block->get_middleware_params() );
+		$attributes      = $processed_block->get_field_group()->get_attributes();
+
+		$repeater_sub_fields = $attributes['fields'][1]['sub_fields'];
+		$field_names = array_column( $repeater_sub_fields, 'name', 'name' );
+		$this->assertArrayNotHasKey( 'taxonomies', $field_names );
+
+		// We don't have other fields rather than post selection
+		$manual_repeater_sub_fields = $repeater_sub_fields[2]['sub_fields'];
+		$field_names = array_column( $manual_repeater_sub_fields, 'name', 'name' );
+		$this->assertArrayNotHasKey( Post_Loop_Field_Middleware::MANUAL_TOGGLE, $field_names );
+	}
+
+	public function test_it_has_taxonomy_filtering() {
+		$block = new class extends Block_Config implements Has_Middleware_Params {
+
+			use With_Field_Prefix;
+
+			public const NAME = 'test_block';
+
+			public const SECTION_CARDS = 's-cards';
+			public const CARD_LIST     = 'card_list';
+
+			public function add_block() {
+				$this->set_block( new Block( self::NAME, [
+					'title' => esc_html__( 'A Test Block', 'tribe' ),
+				] ) );
+			}
+
+			public function add_fields() {
+				// Populated via Block Middleware
+				$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( 'Cards', 'tribe' ), 'accordion' ) );
+			}
+
+			/**
+			 * Config the query post loop field for middleware.
+			 *
+			 * @return array<array{post_loop_field_configs: \Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config[]}>
+			 */
+			public function get_middleware_params(): array {
+				$config              = new Post_Loop_Field_Config();
+				$config->field_name  = self::CARD_LIST;
+				$config->group       = $this->get_section_key( self::SECTION_CARDS );
+				$config->limit_min   = 2;
+				$config->limit_max   = 10;
+
+				return [
+					[
+						Post_Loop_Field_Middleware::MIDDLEWARE_KEY => [
+							$config,
+						],
+					],
+				];
+			}
+
+		};
+
+		$block_field_guard = new Block_Field_Middleware_Guard( new Map( [
+			get_class( $block ) => [
+				Post_Loop_Field_Middleware::class,
+			],
+		] ) );
+
+		$pipeline = $this->container->make( Pipeline::class )
+			->via( 'add_fields' )
+			->through( [
+				new Post_Loop_Field_Middleware( $block_field_guard ),
+			] );
+
+		$processed_block = ( new Add_Fields_Pipeline( $pipeline ) )->process( $block, $block->get_middleware_params() );
+		$attributes      = $processed_block->get_field_group()->get_attributes();
+
+		$repeater_sub_fields = $attributes['fields'][1]['sub_fields'];
+		$field_names = array_column( $repeater_sub_fields, 'name', 'name' );
+		$this->assertArrayHasKey( 'taxonomies', $field_names );
+	}
+
 }

--- a/dev/tests/tests/integration/Tribe/Project/Blocks/Middleware/Post_Loop/Field_Middleware/PostLoopFieldMiddlewareTest.php
+++ b/dev/tests/tests/integration/Tribe/Project/Blocks/Middleware/Post_Loop/Field_Middleware/PostLoopFieldMiddlewareTest.php
@@ -219,7 +219,7 @@ final class PostLoopFieldMiddlewareTest extends Test_Case {
 				$config->limit_min   = 2;
 				$config->limit_max   = 10;
 
-				$config->show_overwrite_options = false;
+				$config->show_override_options = false;
 				$config->show_taxonomy_filter   = false;
 
 				return [

--- a/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
+++ b/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
@@ -88,7 +88,7 @@ class Post_Loop_Field_Config extends Field_Model {
 	/**
 	 * Should show Override fields on Manual query
 	 */
-	public bool $show_overwrite_options = true;
+	public bool $show_override_options = true;
 
 	/**
 	 * The minimum number of posts a user can limit the display to in

--- a/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
+++ b/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Config/Post_Loop_Field_Config.php
@@ -81,6 +81,16 @@ class Post_Loop_Field_Config extends Field_Model {
 	];
 
 	/**
+	 * Should show 'Filter By Taxonomy Terms' group
+	 */
+	public bool $show_taxonomy_filter = true;
+
+	/**
+	 * Should show Override fields on Manual query
+	 */
+	public bool $show_overwrite_options = true;
+
+	/**
 	 * The minimum number of posts a user can limit the display to in
 	 * dynamic query or manual post creation modes.
 	 */

--- a/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Field_Middleware/Post_Loop_Field_Middleware.php
+++ b/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Field_Middleware/Post_Loop_Field_Middleware.php
@@ -326,7 +326,7 @@ class Post_Loop_Field_Middleware extends Abstract_Field_Middleware implements Ct
 			'post_type'  => $this->config->post_types_manual,
 		] );
 
-		if ( $this->config->show_overwrite_options ) {
+		if ( $this->config->show_override_options ) {
 			$fields[] = new Field( $this->build_field_key( self::MANUAL_TOGGLE ), [
 				'label' => esc_html__( 'Create or Override Content', 'tribe' ),
 				'name'  => self::MANUAL_TOGGLE,

--- a/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Field_Middleware/Post_Loop_Field_Middleware.php
+++ b/wp-content/plugins/core/src/Blocks/Middleware/Post_Loop/Field_Middleware/Post_Loop_Field_Middleware.php
@@ -128,7 +128,11 @@ class Post_Loop_Field_Middleware extends Abstract_Field_Middleware implements Ct
 
 		$fields[] = $this->get_query_type_field();
 		$fields[] = $this->get_query_group();
-		$fields[] = $this->get_taxonomy_filter_group();
+
+		if ( $this->config->show_taxonomy_filter ) {
+			$fields[] = $this->get_taxonomy_filter_group();
+		}
+
 		$fields[] = $this->get_manual_query_repeater();
 
 		return $fields;
@@ -322,119 +326,120 @@ class Post_Loop_Field_Middleware extends Abstract_Field_Middleware implements Ct
 			'post_type'  => $this->config->post_types_manual,
 		] );
 
-		$fields[] = new Field( $this->build_field_key( self::MANUAL_TOGGLE ), [
-			'label' => esc_html__( 'Create or Override Content', 'tribe' ),
-			'name'  => self::MANUAL_TOGGLE,
-			'type'  => 'true_false',
-		] );
+		if ( $this->config->show_overwrite_options ) {
+			$fields[] = new Field( $this->build_field_key( self::MANUAL_TOGGLE ), [
+				'label' => esc_html__( 'Create or Override Content', 'tribe' ),
+				'name'  => self::MANUAL_TOGGLE,
+				'type'  => 'true_false',
+			] );
 
-		$fields[] = new Field( $this->build_field_key( self::MANUAL_TITLE ), [
-			'label'             => esc_html__( 'Post Title', 'tribe' ),
-			'name'              => self::MANUAL_TITLE,
-			'type'              => 'text',
-			'conditional_logic' => [
+			$fields[] = new Field( $this->build_field_key( self::MANUAL_TITLE ), [
+				'label'             => esc_html__( 'Post Title', 'tribe' ),
+				'name'              => self::MANUAL_TITLE,
+				'type'              => 'text',
+				'conditional_logic' => [
+					[
+						'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
+						'operator' => '==',
+						'value'    => '1',
+					],
+				],
+			] );
+
+			$fields[] = new Field( $this->build_field_key( self::MANUAL_POST_DATE ), [
+				'label'             => esc_html__( 'Post Date', 'tribe' ),
+				'name'              => self::MANUAL_POST_DATE,
+				'type'              => 'date_time_picker',
+				'instructions'      => esc_html__( 'Set or override the post date.', 'tribe' ),
+				'display_format'    => 'F j, Y g:i a',
+				'return_format'     => 'Y-m-d H:i:s',
+				'first_day'         => true,
+				'conditional_logic' => [
+					[
+						'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
+						'operator' => '==',
+						'value'    => '1',
+					],
+				],
+			] );
+
+			$fields[] = new Field( $this->build_field_key( self::MANUAL_POST_AUTHOR ), [
+				'label'             => esc_html__( 'Post Author', 'tribe' ),
+				'name'              => self::MANUAL_POST_AUTHOR,
+				'type'              => 'user',
+				'instructions'      => esc_html__( 'Set or override the post author.', 'tribe' ),
+				'required'          => false,
+				'role'              => [], // an array of roles to filter by
+				'allow_null'        => true,
+				'multiple'          => false,
+				'return_format'     => 'id', // array, object, id
+				'conditional_logic' => [
+					[
+						'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
+						'operator' => '==',
+						'value'    => '1',
+					],
+				],
+			] );
+
+			$fields[] = new Field( $this->build_field_key( self::MANUAL_POST_CATEGORY ), [
+				'label'             => esc_html__( 'Post Category', 'tribe' ),
+				'name'              => self::MANUAL_POST_CATEGORY,
+				'type'              => 'taxonomy',
+				'instructions'      => esc_html__( 'Set or override the primary post category.', 'tribe' ),
+				'taxonomy'          => Category::NAME,
+				'field_type'        => 'select',
+				'add_term'          => false,
+				'save_terms'        => false,
+				'load_terms'        => false,
+				'multiple'          => false,
+				'allow_null'        => true,
+				'return_format'     => 'id',
+				'conditional_logic' => [
+					[
+						'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
+						'operator' => '==',
+						'value'    => '1',
+					],
+				],
+			] );
+
+			$fields[] = new Field( $this->build_field_key( self::MANUAL_EXCERPT ), [
+				'label'             => esc_html__( 'Post Excerpt', 'tribe' ),
+				'name'              => self::MANUAL_EXCERPT,
+				'type'              => 'textarea',
+				'conditional_logic' => [
+					[
+						'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
+						'operator' => '==',
+						'value'    => '1',
+					],
+				],
+			] );
+
+			$fields[] = $this->get_cta_field( $this->config->field_name, [
 				[
 					'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
 					'operator' => '==',
 					'value'    => '1',
 				],
-			],
-		] );
+			] );
 
-		$fields[] = new Field( $this->build_field_key( self::MANUAL_POST_DATE ), [
-			'label'             => esc_html__( 'Post Date', 'tribe' ),
-			'name'              => self::MANUAL_POST_DATE,
-			'type'              => 'date_time_picker',
-			'instructions'      => esc_html__( 'Set or override the post date.', 'tribe' ),
-			'display_format'    => 'F j, Y g:i a',
-			'return_format'     => 'Y-m-d H:i:s',
-			'first_day'         => true,
-			'conditional_logic' => [
-				[
-					'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
-					'operator' => '==',
-					'value'    => '1',
+			$fields[] = new Field( $this->build_field_key( self::MANUAL_IMAGE ), [
+				'label'             => esc_html__( 'Image', 'tribe' ),
+				'name'              => self::MANUAL_IMAGE,
+				'type'              => 'image',
+				'return_format'     => 'array',
+				'instructions'      => $this->config->image_instructions,
+				'conditional_logic' => [
+					[
+						'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
+						'operator' => '==',
+						'value'    => '1',
+					],
 				],
-			],
-		] );
-
-		$fields[] = new Field( $this->build_field_key( self::MANUAL_POST_AUTHOR ), [
-			'label'             => esc_html__( 'Post Author', 'tribe' ),
-			'name'              => self::MANUAL_POST_AUTHOR,
-			'type'              => 'user',
-			'instructions'      => esc_html__( 'Set or override the post author.', 'tribe' ),
-			'required'          => false,
-			'role'              => [], // an array of roles to filter by
-			'allow_null'        => true,
-			'multiple'          => false,
-			'return_format'     => 'id', // array, object, id
-			'conditional_logic' => [
-				[
-					'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
-					'operator' => '==',
-					'value'    => '1',
-				],
-			],
-		] );
-
-		$fields[] = new Field( $this->build_field_key( self::MANUAL_POST_CATEGORY ), [
-			'label'             => esc_html__( 'Post Category', 'tribe' ),
-			'name'              => self::MANUAL_POST_CATEGORY,
-			'type'              => 'taxonomy',
-			'instructions'      => esc_html__( 'Set or override the primary post category.', 'tribe' ),
-			'taxonomy'          => Category::NAME,
-			'field_type'        => 'select',
-			'add_term'          => false,
-			'save_terms'        => false,
-			'load_terms'        => false,
-			'multiple'          => false,
-			'allow_null'        => true,
-			'return_format'     => 'id',
-			'conditional_logic' => [
-				[
-					'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
-					'operator' => '==',
-					'value'    => '1',
-				],
-			],
-		] );
-
-		$fields[] = new Field( $this->build_field_key( self::MANUAL_EXCERPT ), [
-			'label'             => esc_html__( 'Post Excerpt', 'tribe' ),
-			'name'              => self::MANUAL_EXCERPT,
-			'type'              => 'textarea',
-			'conditional_logic' => [
-				[
-					'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
-					'operator' => '==',
-					'value'    => '1',
-				],
-			],
-		] );
-
-		$fields[] = $this->get_cta_field( $this->config->field_name, [
-			[
-				'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
-				'operator' => '==',
-				'value'    => '1',
-			],
-		] );
-
-		$fields[] = new Field( $this->build_field_key( self::MANUAL_IMAGE ), [
-			'label'             => esc_html__( 'Image', 'tribe' ),
-			'name'              => self::MANUAL_IMAGE,
-			'type'              => 'image',
-			'return_format'     => 'array',
-			'instructions'      => $this->config->image_instructions,
-			'conditional_logic' => [
-				[
-					'field'    => $this->get_key_with_prefix( $this->build_field_key( self::MANUAL_TOGGLE ) ),
-					'operator' => '==',
-					'value'    => '1',
-				],
-			],
-		] );
-
+			] );
+		}
 		return $this->add_fields_to_parent( $repeater, $fields );
 	}
 


### PR DESCRIPTION
## What does this do/fix?

Add to parameters to Post_Loop_Field_Config:
- `show_taxonomy_filter` - allows hiding taxonomy filtering fields. Useful when you have several post types in block and someone doesn't have taxonomies. E.g Pages
- `show_override_option` - allow to hide Override fields for manual query. Instead of hide some fields or provide full list of it, completely hide whole section
Default value for the fields is true - both sections are enabled by default
Add basic test coverage for the feature

The idea came from different projects where we have to hide those fields, so client won't have ability to change it or caught into error or misunderstanding 

## QA

Screenshots/video:
-  http://p.tri.be/i/G2fp3U
- http://p.tri.be/i/qzfoHa
- http://p.tri.be/i/vOzZKs
- http://p.tri.be/i/7UItO3

## Tests

Does this have tests?

- [x] Yes
- [ ] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.

