### PR TITLE
This check should be looking for an empty value.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2023.01
 * Added: 2 parameters are added to the Post_Loop_Field_Config class. `show_taxonomy_filter` - allows hiding taxonomy filtering fields. `show_override_option` - allow hiding Override fields group for manual query
+* Fixed: Content Loop Block Controller method for `get_cta()` was returning early on a `true` boolean value. Should have been `false`.
 
 ## 2022.12
 * Added: .deploy-ignore file and updated deployments to use it to decide which file type should never get synced and deployed to web servers.

--- a/wp-content/themes/core/components/blocks/content_loop/Content_Loop_Controller.php
+++ b/wp-content/themes/core/components/blocks/content_loop/Content_Loop_Controller.php
@@ -148,7 +148,7 @@ class Content_Loop_Controller extends Abstract_Controller {
 	}
 
 	public function get_cta(): ?Deferred_Component {
-		if ( $this->cta->link->url ) {
+		if ( empty( $this->cta->link->url ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
## What does this do/fix?

Found this one out the hard way. It should be looking for an empty string. Surprised that [this is 5 months old](https://github.com/moderntribe/square-one/blame/ef0d180925a5dfef6d205b33c79157bcbf5330e0/wp-content/themes/core/components/blocks/content_loop/Content_Loop_Controller.php#L151).

Let's get this one merged before someone else get hit with it.
