### PR TITLE
SQONE-718: Remove extraneous quote in primary nav walker

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2023.02
+* Fixed: Removed extraneous quote in primary nav walker causing invalid `aria-controls` attribute in primary nav dropdown.
 ## 2023.01
 * Added: 2 parameters are added to the Post_Loop_Field_Config class. `show_taxonomy_filter` - allows hiding taxonomy filtering fields. `show_override_option` - allow hiding Override fields group for manual query
 * Fixed: Content Loop Block Controller method for `get_cta()` was returning early on a `true` boolean value. Should have been `false`.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2023.02
 * Fixed: Removed extraneous quote in primary nav walker causing invalid `aria-controls` attribute in primary nav dropdown.
+
 ## 2023.01
 * Added: 2 parameters are added to the Post_Loop_Field_Config class. `show_taxonomy_filter` - allows hiding taxonomy filtering fields. `show_override_option` - allow hiding Override fields group for manual query
 * Fixed: Content Loop Block Controller method for `get_cta()` was returning early on a `true` boolean value. Should have been `false`.

--- a/wp-content/plugins/core/src/Nav_Menus/Walker/Walker_Nav_Menu_Primary.php
+++ b/wp-content/plugins/core/src/Nav_Menus/Walker/Walker_Nav_Menu_Primary.php
@@ -154,7 +154,7 @@ class Walker_Nav_Menu_Primary extends Walker_Nav_Menu {
 			$atts['title']         = esc_attr__( 'Toggle Sub-Menu', 'tribe' );
 			$atts['aria-expanded'] = 'false';
 			$atts['aria-haspopup'] = 'true';
-			$atts['aria-controls'] = 'menu-item-child-' . esc_attr( $this->current_item->ID ) . '"';
+			$atts['aria-controls'] = 'menu-item-child-' . esc_attr( $this->current_item->ID );
 		}
 
 		$attributes = '';


### PR DESCRIPTION
## What does this do/fix?

Without this patch, the primary nav menu outputs an invalid `aria-controls` attribute for primary menu dropdowns that looks like this:

```
<button 
  title="Toggle Sub-Menu" id="menu-item-4"
  class="c-nav-primary__action c-nav-primary__action--depth-0 c-nav-primary__action--has-children"
  data-js="c-nav-child-menu-trigger"
  aria-expanded="true"
  aria-haspopup="true"
  aria-controls="menu-item-child-4&quot;"
>
  About Us
</button>
```
Note the trailing escaped `&quot;` character in the `aria-controls` attribute, which makes this an invalid ARIA attribute for controlling the `#menu-item-child-4` dropdown.

## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/SQONE-718

