### PR TITLE
Fix for multiple TinyMCE editors on the same page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2023.02
+* Fixed: Fixed the TinyMCE floating toolbar fix, which would break with multiple editors active on the same page.
 * Fixed: Removed extraneous quote in primary nav walker causing invalid `aria-controls` attribute in primary nav dropdown.
 
 ## 2023.01

--- a/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
+++ b/wp-content/themes/core/assets/js/src/admin/editor/tribe-tinymce.js
@@ -27,7 +27,6 @@
  */
 ( function() {
 	window.tinymce.PluginManager.add( 'tribe-tinymce', function( editor ) {
-		let mceIframe;
 		let currentSelection;
 
 		editor.on( 'nodechange', function( event ) {
@@ -35,17 +34,18 @@
 		} );
 
 		editor.on( 'init', function() {
-			mceIframe = document.getElementById( editor.id + '_ifr' );
-
 			window.tinymce.$( '.mce-inline-toolbar-grp:not(.tribe-tinymce-processed)' ).each( ( index, toolbar ) => {
 				toolbar.classList.add( 'tribe-tinymce-processed' );
 
-				const observer = new MutationObserver( function( ) {
+				const observer = new MutationObserver( function() {
 					// Only respond when there is a current selection and the toolbar has
 					// the specific class condition we need to fix.
 					if ( ! currentSelection || ! toolbar.classList.contains( 'mce-arrow-left' ) ) {
 						return;
 					}
+
+					// Get the current editor Iframe.
+					const mceIframe = document.getElementById( window.wpActiveEditor + '_ifr' );
 
 					// We are essentially overriding the reposition() function in
 					// wp-includes/js/tinymce/plugins/wordpress/plugin.js to prevent


### PR DESCRIPTION
## What does this do/fix?

This patch fixes an edge case where there are multiple TinyMCE editors active on a given page (imagine _Appearance → Theme Configuration_ with multiple tabs, several of which have a WYSIWYG field, for example). Without this patch, the `tribe-tinymce` plugin (which itself fixes a different core Wordpress + TinyMCE bug) fails to find the correct editor and breaks TinyMCE floating toolbar positioning (they end up positioned offscreen and unusable).


## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/SQONE-719
