### PR TITLE
Bugfix/builds fail due to browserlist key change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+# 2023.03
+* Fixed: Reverted browserlist "not dead" key.
+
 ## 2023.02
 * Updated: Browserlist versions to latest.
 * Fixed: The `ci.yml` GitHub workflow will now use the properly configured PHP version. It will also only change the composer cached based on the root composer.lock file.

--- a/package.json
+++ b/package.json
@@ -44,8 +44,12 @@
     "safari >= 15",
     "ios >= 15",
     "android >= 8.0",
+    "not ie <= 11",
+    "not ie_mob <= 11",
     "not op_mini all",
-    "not dead"
+    "not bb <= 10",
+    "not samsung 4",
+    "not op_mob <= 12.1"
   ],
   "engines": {
     "node": "16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,9 +3730,9 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   integrity sha512-r5F4eY7LpqtmNdMe1tZmut2fKKE0SFjuUoX3PlYLE4UHK1rLw1m64792vg6iuOucZI5HNhocB1F7YEo4aJe0lg==
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001280:
-  version "1.0.30001286"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz#3e9debad420419618cfdf52dc9b6572b28a8fff6"
-  integrity sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==
+  version "1.0.30001462"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz"
+  integrity sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What does this do/fix?
Reverts the browserlist key usage "not dead" in favor of named browsers as the new key doesn't appear supported with our current set of npm packages.
